### PR TITLE
Clear all pills

### DIFF
--- a/lib/bloc/pill/pill_bloc.dart
+++ b/lib/bloc/pill/pill_bloc.dart
@@ -13,6 +13,7 @@ class PillBloc extends Bloc<PillEvent, PillState> {
     on<AddPill>(_onAddPill);
     on<UpdatePill>(_onUpdatePill);
     on<DeletePill>(_onDeletePill);
+    on<ClearAllPills>(_onClearAllPills);
   }
 
   void _onLoadPills(LoadPill event, Emitter<PillState> emitter) {
@@ -64,6 +65,18 @@ class PillBloc extends Bloc<PillEvent, PillState> {
           pillsToTake: updatedPills,
           pillsTaken: pillsTaken),
       );
+    }
+  }
+
+  void _onClearAllPills(ClearAllPills event, Emitter<PillState> emitter) {
+    final state = this.state;
+    if (state is PillLoaded) {
+      String date = DateService().getCurrentDateAsMonthAndDay();
+      List<PillTaken> pillsTaken = SharedPreferencesService().getPillsTakenForDate(date);
+        emitter(PillLoaded(
+          pillsToTake: const <PillToTake>[],
+          pillsTaken: pillsTaken),
+        );
     }
   }
 

--- a/lib/bloc/pill/pill_event.dart
+++ b/lib/bloc/pill/pill_event.dart
@@ -57,3 +57,9 @@ class DeletePill extends PillEvent {
   @override
   List<Object> get props => [pillToTake];
 }
+
+class ClearAllPills extends PillEvent {
+  ClearAllPills() {
+    SharedPreferencesService().clearAllPills();
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -17,12 +17,13 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MultiBlocProvider(
-        providers: [BlocProvider(
+        providers: [
+          BlocProvider(
           create: (context) => PillBloc()
             ..add(LoadPill(),),
-        ),
-        BlocProvider(create:
-        (context) => PillFilterBloc(pillBloc: BlocProvider.of<PillBloc>(context)
+          ),
+          BlocProvider(
+            create: (context) => PillFilterBloc(pillBloc: BlocProvider.of<PillBloc>(context)
             ),
           ),
         ],

--- a/lib/page/main_page.dart
+++ b/lib/page/main_page.dart
@@ -42,8 +42,6 @@ class _MainPageState extends State<MainPage> with SingleTickerProviderStateMixin
         case 1:
           context.read<PillFilterBloc>().add(UpdatePills(pillFilter: PillFilter.taken));
           break;
-        case 2:
-          break;
       }
     });
   }
@@ -69,8 +67,6 @@ class _MainPageState extends State<MainPage> with SingleTickerProviderStateMixin
                             pillFilter: PillFilter.taken
                         ));
                         break;
-                      case 2:
-                          break;
                     }
                   }, tabs: [
                   Tab(icon: Icon(CustomIcons.pill)),

--- a/lib/page/main_page.dart
+++ b/lib/page/main_page.dart
@@ -109,22 +109,9 @@ class _MainPageState extends State<MainPage> with SingleTickerProviderStateMixin
                       title:  "You have not taken any pills today"),
                 ],
               ),
-              Column(
-                  mainAxisAlignment: MainAxisAlignment.start,
-                  children: [
-                    ListTile(
-                        title: const Text("Clear All Pills"),
-                        leading: const Icon(
-                            Icons.clear,
-                            color: Colors.redAccent),
-                        onTap: () {
-
-                        }
-                    ),
-                  ]
-              )
-            ],
-          ),
+              SettingsPage()
+            ]
+          )
         );
   }
 }

--- a/lib/page/main_page.dart
+++ b/lib/page/main_page.dart
@@ -4,6 +4,7 @@ import 'package:pill/bloc/pill_filter/pill_filter_bloc.dart';
 import 'package:pill/bloc/pill_filter/pill_filter_event.dart';
 import 'package:pill/custom_icons.dart';
 import 'package:pill/model/pill_filter.dart';
+import 'package:pill/page/settings_page.dart';
 import 'package:pill/service/shared_preferences_service.dart';
 import 'package:pill/widget/day_widget.dart';
 import 'package:pill/widget/adding_pill_form.dart';
@@ -32,7 +33,7 @@ class _MainPageState extends State<MainPage> with SingleTickerProviderStateMixin
   void initState() {
     super.initState();
     SharedPreferencesService().clearPillsOfPastDays();
-    _controller = TabController(length: 2, vsync: this);
+    _controller = TabController(length: 3, vsync: this);
     _controller.addListener(() {
       switch(_controller.index) {
         case 0:
@@ -40,6 +41,8 @@ class _MainPageState extends State<MainPage> with SingleTickerProviderStateMixin
           break;
         case 1:
           context.read<PillFilterBloc>().add(UpdatePills(pillFilter: PillFilter.taken));
+          break;
+        case 2:
           break;
       }
     });
@@ -66,10 +69,13 @@ class _MainPageState extends State<MainPage> with SingleTickerProviderStateMixin
                             pillFilter: PillFilter.taken
                         ));
                         break;
+                      case 2:
+                          break;
                     }
                   }, tabs: [
                   Tab(icon: Icon(CustomIcons.pill)),
                   Tab(icon: Icon(Icons.watch_later_rounded)),
+                  Tab(icon: Icon(Icons.settings)),
                 ],
                 controller: _controller,
               ),
@@ -103,6 +109,20 @@ class _MainPageState extends State<MainPage> with SingleTickerProviderStateMixin
                       title:  "You have not taken any pills today"),
                 ],
               ),
+              Column(
+                  mainAxisAlignment: MainAxisAlignment.start,
+                  children: [
+                    ListTile(
+                        title: const Text("Clear All Pills"),
+                        leading: const Icon(
+                            Icons.clear,
+                            color: Colors.redAccent),
+                        onTap: () {
+
+                        }
+                    ),
+                  ]
+              )
             ],
           ),
         );

--- a/lib/page/settings_page.dart
+++ b/lib/page/settings_page.dart
@@ -16,7 +16,30 @@ class SettingsPage extends StatelessWidget {
                           Icons.clear,
                           color: Colors.redAccent),
                       onTap: () {
-                        BlocProvider.of<PillBloc>(context).add(ClearAllPills());
+                        AlertDialog alertDialog = AlertDialog(
+                          title: const Text("Clear All Saved Pills"),
+                          content: const Text("Are you sure you want to remove all your saved pills?"),
+                          actions: [
+                            TextButton(
+                                onPressed: () {
+                                  BlocProvider.of<PillBloc>(context).add(ClearAllPills());
+                                  Navigator.pop(context);
+                                },
+                                child: const Text("Yes")
+                            ),
+                            TextButton(
+                                onPressed: () {
+                                  Navigator.pop(context);
+                                },
+                                child: const Text("No")
+                            ),
+                          ],
+                        );
+                        showDialog(
+                            context: context,
+                            builder: (BuildContext context) {
+                            return alertDialog;
+                        });
                       }
                   ),
                 ]

--- a/lib/page/settings_page.dart
+++ b/lib/page/settings_page.dart
@@ -1,4 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:pill/bloc/pill/pill_bloc.dart';
+import 'package:pill/bloc/pill/pill_event.dart';
 
 class SettingsPage extends StatelessWidget {
 
@@ -13,7 +16,7 @@ class SettingsPage extends StatelessWidget {
                           Icons.clear,
                           color: Colors.redAccent),
                       onTap: () {
-
+                        BlocProvider.of<PillBloc>(context).add(ClearAllPills());
                       }
                   ),
                 ]

--- a/lib/page/settings_page.dart
+++ b/lib/page/settings_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:pill/bloc/pill/pill_bloc.dart';
 import 'package:pill/bloc/pill/pill_event.dart';
+import 'package:pill/service/shared_preferences_service.dart';
 
 class SettingsPage extends StatelessWidget {
 
@@ -15,6 +16,7 @@ class SettingsPage extends StatelessWidget {
                       leading: const Icon(
                           Icons.clear,
                           color: Colors.redAccent),
+                      enabled: SharedPreferencesService().areThereAnyPillsToTake(),
                       onTap: () {
                         AlertDialog alertDialog = AlertDialog(
                           title: const Text("Clear All Saved Pills"),

--- a/lib/page/settings_page.dart
+++ b/lib/page/settings_page.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+
+class SettingsPage extends StatelessWidget {
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+                mainAxisAlignment: MainAxisAlignment.start,
+                children: [
+                  ListTile(
+                      title: const Text("Clear All Pills"),
+                      leading: const Icon(
+                          Icons.clear,
+                          color: Colors.redAccent),
+                      onTap: () {
+
+                      }
+                  ),
+                ]
+            );
+        }
+}

--- a/lib/service/shared_preferences_service.dart
+++ b/lib/service/shared_preferences_service.dart
@@ -143,7 +143,7 @@ class SharedPreferencesService {
 
   bool areThereAnyPillsToTake() {
     Set<String>? keys = _sharedPreferences?.getKeys();
-    if (keys == null) return false;
+    if (keys == null || keys.length == 0) return false;
     if (keys.length == 1 && keys.first.contains(TIME_APP_OPENED_KEY)) return false;
     return true;
   }

--- a/lib/service/shared_preferences_service.dart
+++ b/lib/service/shared_preferences_service.dart
@@ -141,4 +141,11 @@ class SharedPreferencesService {
     }
   }
 
+  bool areThereAnyPillsToTake() {
+    Set<String>? keys = _sharedPreferences?.getKeys();
+    if (keys == null) return false;
+    if (keys.length == 1 && keys.first.contains(TIME_APP_OPENED_KEY)) return false;
+    return true;
+  }
+
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -21,7 +21,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.2"
+    version: "2.9.0"
   bloc:
     dependency: transitive
     description:
@@ -42,28 +42,21 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
-  charcode:
-    dependency: transitive
-    description:
-      name: charcode
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.3.1"
+    version: "1.2.1"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   crypto:
     dependency: transitive
     description:
@@ -84,7 +77,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.3.1"
   ffi:
     dependency: transitive
     description:
@@ -141,28 +134,28 @@ packages:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.3"
+    version: "0.6.4"
   matcher:
     dependency: transitive
     description:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.11"
+    version: "0.12.12"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.3"
+    version: "0.1.5"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.7.0"
+    version: "1.8.0"
   nested:
     dependency: transitive
     description:
@@ -176,7 +169,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.2"
   path_provider_linux:
     dependency: transitive
     description:
@@ -300,7 +293,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.9.0"
   stack_trace:
     dependency: transitive
     description:
@@ -321,21 +314,21 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.8"
+    version: "0.4.12"
   typed_data:
     dependency: transitive
     description:
@@ -349,7 +342,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   win32:
     dependency: transitive
     description:
@@ -379,5 +372,5 @@ packages:
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=2.15.0 <3.0.0"
+  dart: ">=2.17.0-0 <3.0.0"
   flutter: ">=2.8.0"

--- a/test/shared_preferences_test.dart
+++ b/test/shared_preferences_test.dart
@@ -1,6 +1,3 @@
-
-import 'dart:math';
-
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pill/model/pill_to_take.dart';
 import 'package:pill/service/date_service.dart';

--- a/test/shared_preferences_test.dart
+++ b/test/shared_preferences_test.dart
@@ -1,4 +1,6 @@
 
+import 'dart:math';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pill/model/pill_to_take.dart';
 import 'package:pill/service/date_service.dart';
@@ -64,6 +66,25 @@ void main() {
     PillToTake updatedPill = pills[0];
 
     expect(updatedPill.pillRegiment, 10);
+  });
+
+  test("SharedPreferences Service Clearing All Pills", () {
+    PillToTake pill = new PillToTake(pillName: "Test Pill", pillRegiment: 2, amountOfDaysToTake: 1);
+    SharedPreferencesService().addPillToDates(date, pill);
+    List<PillToTake> pills = SharedPreferencesService().getPillsToTakeForDate(date);
+
+    expect(pills.length, 1);
+
+    bool areTherePillsToTake = SharedPreferencesService().areThereAnyPillsToTake();
+
+    expect(areTherePillsToTake, true);
+
+    SharedPreferencesService().clearAllPills();
+
+    areTherePillsToTake = SharedPreferencesService().areThereAnyPillsToTake();
+
+    expect(areTherePillsToTake, false);
+
   });
 
 }


### PR DESCRIPTION
Fixes #6 

Adding UI and logic to provide users with a way to clear all their saved pills from the application. A sort of reset, if you will.
This required adding another tab, adding another event for the pill bloc.

The option for clearing all pills for a specific day was discarded as it is deemed not to be as relevant since users can easily swipe away pills.
