### PR TITLE
Dark mode

### DIFF
--- a/lib/bloc/theme/theme_block.dart
+++ b/lib/bloc/theme/theme_block.dart
@@ -1,0 +1,20 @@
+
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:pill/bloc/theme/theme_event.dart';
+import 'package:pill/bloc/theme/theme_state.dart';
+
+class ThemeBloc extends Bloc<ThemeEvent, ThemeState> {
+  ThemeBloc(): super(LightMode()) {
+    on<ChangeTheme>(_onThemeChange);
+  }
+
+  void _onThemeChange(ChangeTheme event, Emitter<ThemeState> emitter) {
+    if (event.isDarkThemeEnabled) {
+      emitter(DarkMode());
+    } else {
+      emitter(LightMode());
+    }
+  }
+
+
+}

--- a/lib/bloc/theme/theme_block.dart
+++ b/lib/bloc/theme/theme_block.dart
@@ -4,7 +4,7 @@ import 'package:pill/bloc/theme/theme_event.dart';
 import 'package:pill/bloc/theme/theme_state.dart';
 
 class ThemeBloc extends Bloc<ThemeEvent, ThemeState> {
-  ThemeBloc(): super(LightMode()) {
+  ThemeBloc(): super(InitialTheme()) {
     on<ChangeTheme>(_onThemeChange);
   }
 
@@ -15,6 +15,4 @@ class ThemeBloc extends Bloc<ThemeEvent, ThemeState> {
       emitter(LightMode());
     }
   }
-
-
 }

--- a/lib/bloc/theme/theme_event.dart
+++ b/lib/bloc/theme/theme_event.dart
@@ -1,4 +1,4 @@
-
+import 'package:pill/service/shared_preferences_service.dart';
 
 abstract class ThemeEvent {
   const ThemeEvent();
@@ -9,7 +9,9 @@ abstract class ThemeEvent {
 class ChangeTheme extends ThemeEvent {
   bool darkThemeEnabled = false;
 
-  ChangeTheme({required this.darkThemeEnabled});
+  ChangeTheme({required this.darkThemeEnabled}) {
+    SharedPreferencesService().saveThemeStatus(darkThemeEnabled);
+  }
 
   @override
   bool get isDarkThemeEnabled => darkThemeEnabled;

--- a/lib/bloc/theme/theme_event.dart
+++ b/lib/bloc/theme/theme_event.dart
@@ -1,0 +1,16 @@
+
+
+abstract class ThemeEvent {
+  const ThemeEvent();
+
+  bool get isDarkThemeEnabled => false;
+}
+
+class ChangeTheme extends ThemeEvent {
+  bool darkThemeEnabled = false;
+
+  ChangeTheme({required this.darkThemeEnabled});
+
+  @override
+  bool get isDarkThemeEnabled => darkThemeEnabled;
+}

--- a/lib/bloc/theme/theme_state.dart
+++ b/lib/bloc/theme/theme_state.dart
@@ -1,8 +1,15 @@
 
+import 'package:pill/service/shared_preferences_service.dart';
+
 abstract class ThemeState {
   const ThemeState();
 
  bool get isDarkModeEnabled => false;
+}
+
+class InitialTheme extends ThemeState {
+  @override
+  bool get isDarkModeEnabled => SharedPreferencesService().getThemeStatus();
 }
 
 class DarkMode extends ThemeState {

--- a/lib/bloc/theme/theme_state.dart
+++ b/lib/bloc/theme/theme_state.dart
@@ -1,0 +1,17 @@
+
+abstract class ThemeState {
+  const ThemeState();
+
+ bool get isDarkModeEnabled => false;
+}
+
+class DarkMode extends ThemeState {
+  @override
+  bool get isDarkModeEnabled => true;
+}
+
+class LightMode extends ThemeState {
+
+  @override
+  bool get isDarkModeEnabled => false;
+}

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -11,3 +11,4 @@ const String ADD_PILL_FORM_CONFIRM = "Apply";
 const String ADD_PILL_FORM_CANCEL = "Cancel";
 const String PILLS_TAKEN_KEY = "pillsTaken";
 const String TIME_APP_OPENED_KEY = "timeAppOpened";
+const String DARK_MODE_KEY = "darkMode";

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:pill/bloc/pill_filter/pill_filter_bloc.dart';
+import 'package:pill/bloc/theme/theme_block.dart';
+import 'package:pill/bloc/theme/theme_event.dart';
+import 'package:pill/bloc/theme/theme_state.dart';
 import 'bloc/pill/pill_event.dart';
 import 'bloc/pill/pill_bloc.dart';
 import 'package:pill/constants.dart';
@@ -17,23 +20,33 @@ class MyApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MultiBlocProvider(
-        providers: [
-          BlocProvider(
+      providers: [
+        BlocProvider(
           create: (context) => PillBloc()
             ..add(LoadPill(),),
+        ),
+        BlocProvider(
+          create: (context) => PillFilterBloc(pillBloc: BlocProvider.of<PillBloc>(context)
           ),
-          BlocProvider(
-            create: (context) => PillFilterBloc(pillBloc: BlocProvider.of<PillBloc>(context)
-            ),
-          ),
-        ],
-        child: MaterialApp(
-      title: APP_TITLE,
-      theme: ThemeData(
-        primarySwatch: Colors.blue,
+        ),
+        BlocProvider(
+            create: (context) => ThemeBloc()..add(ChangeTheme(darkThemeEnabled: false))
+        ),
+      ],
+      child:
+      BlocBuilder<ThemeBloc, ThemeState>(
+          builder: (context, state) {
+            return MaterialApp(
+              title: APP_TITLE,
+              theme: ThemeData(
+                primarySwatch: Colors.blue,
+              ),
+              darkTheme: ThemeData.dark(),
+              themeMode:  state.isDarkModeEnabled ? ThemeMode.dark : ThemeMode.light,
+              home: MainPage(title: APP_TITLE),
+            );
+          }
       ),
-        home: MainPage(title: APP_TITLE),
-      )
     );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:pill/bloc/pill_filter/pill_filter_bloc.dart';
 import 'package:pill/bloc/theme/theme_block.dart';
-import 'package:pill/bloc/theme/theme_event.dart';
 import 'package:pill/bloc/theme/theme_state.dart';
 import 'bloc/pill/pill_event.dart';
 import 'bloc/pill/pill_bloc.dart';
@@ -30,7 +29,7 @@ class MyApp extends StatelessWidget {
           ),
         ),
         BlocProvider(
-            create: (context) => ThemeBloc()..add(ChangeTheme(darkThemeEnabled: false))
+            create: (context) => ThemeBloc()
         ),
       ],
       child:

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -38,9 +38,7 @@ class MyApp extends StatelessWidget {
           builder: (context, state) {
             return MaterialApp(
               title: APP_TITLE,
-              theme: ThemeData(
-                primarySwatch: Colors.blue,
-              ),
+              theme: ThemeData(primarySwatch: Colors.blue),
               darkTheme: ThemeData.dark(),
               themeMode:  state.isDarkModeEnabled ? ThemeMode.dark : ThemeMode.light,
               home: MainPage(title: APP_TITLE),

--- a/lib/page/settings_page.dart
+++ b/lib/page/settings_page.dart
@@ -2,49 +2,64 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:pill/bloc/pill/pill_bloc.dart';
 import 'package:pill/bloc/pill/pill_event.dart';
+import 'package:pill/bloc/theme/theme_block.dart';
+import 'package:pill/bloc/theme/theme_event.dart';
 import 'package:pill/service/shared_preferences_service.dart';
 
 class SettingsPage extends StatelessWidget {
 
+
   @override
   Widget build(BuildContext context) {
     return Column(
-                mainAxisAlignment: MainAxisAlignment.start,
-                children: [
-                  ListTile(
-                      title: const Text("Clear All Pills"),
-                      leading: const Icon(
-                          Icons.clear,
-                          color: Colors.redAccent),
-                      enabled: SharedPreferencesService().areThereAnyPillsToTake(),
-                      onTap: () {
-                        AlertDialog alertDialog = AlertDialog(
-                          title: const Text("Clear All Saved Pills"),
-                          content: const Text("Are you sure you want to remove all your saved pills?"),
-                          actions: [
-                            TextButton(
-                                onPressed: () {
-                                  BlocProvider.of<PillBloc>(context).add(ClearAllPills());
-                                  Navigator.pop(context);
-                                },
-                                child: const Text("Yes")
-                            ),
-                            TextButton(
-                                onPressed: () {
-                                  Navigator.pop(context);
-                                },
-                                child: const Text("No")
-                            ),
-                          ],
-                        );
-                        showDialog(
-                            context: context,
-                            builder: (BuildContext context) {
-                            return alertDialog;
-                        });
-                      }
-                  ),
-                ]
-            );
-        }
+        mainAxisAlignment: MainAxisAlignment.start,
+        children: [
+          SwitchListTile(
+              title: const Text("Dark Mode"),
+              secondary: new Icon(
+                  Icons.dark_mode,
+                  color: BlocProvider.of<ThemeBloc>(context).state.isDarkModeEnabled ?
+                  Color.fromARGB(200, 243, 231, 106) :
+                  Color(0xFF642ef3)
+              ),
+              value: BlocProvider.of<ThemeBloc>(context).state.isDarkModeEnabled,
+              onChanged: (bool isDarkModeEnabled) {
+                BlocProvider.of<ThemeBloc>(context).add(ChangeTheme(darkThemeEnabled: isDarkModeEnabled));
+              }),
+          ListTile(
+              title: const Text("Clear All Pills"),
+              leading: const Icon(
+                  Icons.clear,
+                  color: Colors.redAccent),
+              enabled: SharedPreferencesService().areThereAnyPillsToTake(),
+              onTap: () {
+                AlertDialog alertDialog = AlertDialog(
+                  title: const Text("Clear All Saved Pills"),
+                  content: const Text("Are you sure you want to remove all your saved pills?"),
+                  actions: [
+                    TextButton(
+                        onPressed: () {
+                          BlocProvider.of<PillBloc>(context).add(ClearAllPills());
+                          Navigator.pop(context);
+                        },
+                        child: const Text("Yes")
+                    ),
+                    TextButton(
+                        onPressed: () {
+                          Navigator.pop(context);
+                        },
+                        child: const Text("No")
+                    ),
+                  ],
+                );
+                showDialog(
+                    context: context,
+                    builder: (BuildContext context) {
+                      return alertDialog;
+                    });
+              }
+          ),
+        ]
+    );
+  }
 }

--- a/lib/service/shared_preferences_service.dart
+++ b/lib/service/shared_preferences_service.dart
@@ -148,4 +148,15 @@ class SharedPreferencesService {
     return true;
   }
 
+  void saveThemeStatus(bool isDarkModeEnabled) {
+    _sharedPreferences?.setBool(DARK_MODE_KEY, isDarkModeEnabled);
+  }
+
+  bool getThemeStatus() {
+    bool? darkMode = _sharedPreferences?.getBool(DARK_MODE_KEY);
+    return darkMode != null ?
+      darkMode :
+      false;
+  }
+
 }

--- a/lib/widget/adding_pill_form.dart
+++ b/lib/widget/adding_pill_form.dart
@@ -51,143 +51,139 @@ class AddingPillFormState extends State<AddingPillForm> {
   @override
   Widget build(BuildContext context) {
     return new Scaffold(
-      body:
-          BlocListener<PillBloc, PillState>(
-            listener: (context, state) {
-              if (state is PillLoaded) {
-                ScaffoldMessenger.of(context).showSnackBar(
-                  const SnackBar(content:
-                    const Text("Pill Added!")
-                  ),
-                );
-              }
-            },
-            child:  Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                Text(ADDING_A_PILL_TITLE,
-                    style: TextStyle(fontWeight: FontWeight.bold, fontSize: 20.0)
+        body:
+        BlocListener<PillBloc, PillState>(
+          listener: (context, state) {
+            if (state is PillLoaded) {
+              ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(content:
+                const Text("Pill Added!")
                 ),
-                SizedBox(height: 25.0),
-                Form(
-                  key: _formKey,
-                  child: Column(
-                    children: <Widget>[
-                      Theme(
-                        data: ThemeData(colorScheme:
-                        ThemeData().colorScheme.copyWith(primary:Colors.red)
-                        ),
-                        child:  Container(
-                          width: MediaQuery.of(context).size.width * 0.9,
-                          child: TextFormField(
-                              key: ObjectKey("pillName"),
-                              controller: pillNameTextEditingController,
-                              decoration: const InputDecoration(
-                                  border: OutlineInputBorder(),
-                                  hintText: 'What is the pill\'s name?',
-                                  prefixIcon: Icon(CustomIcons.pill)
+              );
+            }
+          },
+          child:  Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Text(ADDING_A_PILL_TITLE,
+                  style: TextStyle(fontWeight: FontWeight.bold, fontSize: 20.0)
+              ),
+              SizedBox(height: 25.0),
+              Form(
+                key: _formKey,
+                child: Column(
+                  children: <Widget>[
+                    Container(
+                      width: MediaQuery.of(context).size.width * 0.9,
+                      child: TextFormField(
+                          key: ObjectKey("pillName"),
+                          controller: pillNameTextEditingController,
+                          decoration: const InputDecoration(
+                              border: OutlineInputBorder(),
+                              focusedBorder: OutlineInputBorder(
+                                borderSide: BorderSide(color: Colors.red, width: 1),
                               ),
-                              inputFormatters: [
-                                FilteringTextInputFormatter.allow(
-                                    RegExp(r'^[\p{L}\s]*$',
-                                      multiLine: false,
-                                      caseSensitive: true,
-                                      unicode: true
-                                    )),
-                                FilteringTextInputFormatter.singleLineFormatter
-                              ],
-                              validator: (value) {
-                                if (value == null || value.isEmpty) {
-                                  return 'Please enter a pill name';
-                                }
-                                return null;
-                              }
+                              hintText: 'What is the pill\'s name?',
+                              prefixIcon: Icon(CustomIcons.pill, color: Colors.red)
                           ),
-                        ),
-                      ),
-                      SizedBox(height: 25.0),
-                      Container(
-                        width: MediaQuery.of(context).size.width * 0.9,
-                        child:  TextFormField(
-                            key: ObjectKey("pillRegiment"),
-                            controller: pillRegimentController,
-                            keyboardType: TextInputType.number,
-                            decoration: const InputDecoration(
-                                border: OutlineInputBorder(),
-                                hintText: 'How many pills to take per day?',
-                                prefixIcon: Icon(Icons.confirmation_number)
-                            ),
-                            validator: (value) {
-                              if (value == null || value.isEmpty || !_isNumberGreaterThanZero(value)) {
-                                return 'Please enter a number representing the amount of pills to take';
-                              }
-                              return null;
+                          inputFormatters: [
+                            FilteringTextInputFormatter.allow(
+                                RegExp(r'^[\p{L}\s]*$',
+                                    multiLine: false,
+                                    caseSensitive: true,
+                                    unicode: true
+                                )),
+                            FilteringTextInputFormatter.singleLineFormatter
+                          ],
+                          validator: (value) {
+                            if (value == null || value.isEmpty) {
+                              return 'Please enter a pill name';
                             }
-                        ),
+                            return null;
+                          }
                       ),
-                      SizedBox(height: 25.0),
-                      Theme(
-                          data: ThemeData(colorScheme:
-                          ThemeData().colorScheme.copyWith(primary:Colors.green)
+                    ),
+                    SizedBox(height: 25.0),
+                    Container(
+                      width: MediaQuery.of(context).size.width * 0.9,
+                      child:  TextFormField(
+                          key: ObjectKey("pillRegiment"),
+                          controller: pillRegimentController,
+                          keyboardType: TextInputType.number,
+                          decoration: const InputDecoration(
+                              border: OutlineInputBorder(),
+                              hintText: 'How many pills to take per day?',
+                              prefixIcon: Icon(Icons.confirmation_number, color: Colors.blue)
                           ),
-                          child:Container(
-                            width: MediaQuery.of(context).size.width * 0.9,
-                            child:  TextFormField(
-                                key: ObjectKey("pillDays"),
-                                controller: pillAmountOfDaysToTakeController,
-                                keyboardType: TextInputType.number,
-                                decoration: const InputDecoration(
-                                    border: OutlineInputBorder(),
-                                    hintText: 'For How Many Days?',
-                                    prefixIcon: Icon(Icons.calendar_today)
-                                ),
-                                validator: (value) {
-                                  if (value == null || value.isEmpty || !_isNumberGreaterThanZero(value)) {
-                                    return 'Please enter a number representing the number of days';
-                                  }
-                                  return null;
-                                }
-                            ),
-                          )
-                      ),
-                      SizedBox(height: 25.0),
-                      Row(
-                        mainAxisAlignment: MainAxisAlignment.spaceAround,
-                        children: [
-                          ElevatedButton.icon(onPressed: () {
-                            if (_formKey.currentState?.validate() ?? false) {
-                              PillToTake pill = new PillToTake(
-                                  pillName: pillNameTextEditingController.text,
-                                  pillWeight: 0.0,
-                                  pillRegiment: int.parse(pillRegimentController.text),
-                                  description: '',
-                                  amountOfDaysToTake: int.parse(pillAmountOfDaysToTakeController.text));
-
-                              context.read<PillBloc>().add(AddPill(pillToTake: pill));
-
-                              FocusScope.of(context).unfocus();
-                              Navigator.pop(context);
+                          validator: (value) {
+                            if (value == null || value.isEmpty || !_isNumberGreaterThanZero(value)) {
+                              return 'Please enter a number representing the amount of pills to take';
                             }
-                          } ,
-                              icon: Icon(Icons.check, color: Colors.lightGreen),
-                              label: const Text(ADD_PILL_FORM_CONFIRM)
+                            return null;
+                          }
+                      ),
+                    ),
+                    SizedBox(height: 25.0),
+                    Container(
+                      width: MediaQuery.of(context).size.width * 0.9,
+                      child:  TextFormField(
+                          key: ObjectKey("pillDays"),
+                          controller: pillAmountOfDaysToTakeController,
+                          keyboardType: TextInputType.number,
+                          decoration: const InputDecoration(
+                              border: OutlineInputBorder(),
+                              focusedBorder: OutlineInputBorder(
+                                borderSide: BorderSide(color: Colors.green, width: 1),
+                              ),
+                              hintText: 'For How Many Days?',
+                              prefixIcon: Icon(Icons.calendar_today, color: Colors.green)
                           ),
-                          ElevatedButton.icon(
-                            onPressed: () {
-                              FocusScope.of(context).unfocus();
-                              Navigator.pop(context);
-                            },
-                            icon: Icon(Icons.clear, color: Colors.red),
-                            label: const Text(ADD_PILL_FORM_CANCEL),
-                          ),
-                        ],
-                      )
-                    ],
-                  ),
+                          validator: (value) {
+                            if (value == null || value.isEmpty || !_isNumberGreaterThanZero(value)) {
+                              return 'Please enter a number representing the number of days';
+                            }
+                            return null;
+                          }
+                      ),
+                    ),
+                    SizedBox(height: 25.0),
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceAround,
+                      children: [
+                        ElevatedButton.icon(onPressed: () {
+                          if (_formKey.currentState?.validate() ?? false) {
+                            PillToTake pill = new PillToTake(
+                                pillName: pillNameTextEditingController.text,
+                                pillWeight: 0.0,
+                                pillRegiment: int.parse(pillRegimentController.text),
+                                description: '',
+                                amountOfDaysToTake: int.parse(pillAmountOfDaysToTakeController.text));
+
+                            context.read<PillBloc>().add(AddPill(pillToTake: pill));
+
+                            FocusScope.of(context).unfocus();
+                            Navigator.pop(context);
+                          }
+                        } ,
+                            icon: Icon(Icons.check, color: Colors.lightGreen),
+                            label: const Text(ADD_PILL_FORM_CONFIRM)
+                        ),
+                        ElevatedButton.icon(
+                          onPressed: () {
+                            FocusScope.of(context).unfocus();
+                            Navigator.pop(context);
+                          },
+                          icon: Icon(Icons.clear, color: Colors.red),
+                          label: const Text(ADD_PILL_FORM_CANCEL),
+                        ),
+                      ],
+                    )
+                  ],
                 ),
-              ],
-            ),
-          )
+              ),
+            ],
+          ),
+        )
     );
   }
 }


### PR DESCRIPTION
Fixes #20 
To support dark mode it was needed to add another bloc called ThemeBloc. 
Furthermore, another value was added in shared preferences so the theme can be saved.

UI wise, a switch was added to the settings screen to allow changing the theme and for the adding pill form, the colors of the text form fields have been changed due to issues with supporting the colors in dark mode ([SO question](https://stackoverflow.com/questions/74486159/flutter-textformfield-prefix-icon-focus-color-on-theme-change)).

![qemu-system-x86_64_HPfvx9eOwP](https://user-images.githubusercontent.com/23402988/202787812-6f97022a-b03c-43e4-9b9e-72484c2734cb.png)
![qemu-system-x86_64_JkhXOdSRRW](https://user-images.githubusercontent.com/23402988/202787818-f5897e42-775c-4122-943c-2432a72d74ac.png)




