### PR TITLE
Feature/different indication pill last taken

### DIFF
--- a/lib/widget/pill_taken_widget.dart
+++ b/lib/widget/pill_taken_widget.dart
@@ -13,6 +13,8 @@ class PillTakenWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    DateTime? lastTaken = pillToTake.lastTaken;
+
     return Container(
       child: Card(
         child: InkWell(
@@ -34,12 +36,20 @@ class PillTakenWidget extends StatelessWidget {
                       color: Utils.getPillTakenImageColor(context))
                 ],
               ),
-              Row(mainAxisAlignment: MainAxisAlignment.center, children: [
-                Icon(Icons.access_time),
-                Text(dateService.getHourFromDate(pillToTake.lastTaken!),
-                    style:
-                        TextStyle(fontSize: 20.0, fontWeight: FontWeight.bold))
-              ])
+              Row(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: lastTaken != null
+                      ? [
+                          Icon(Icons.access_time),
+                          Padding(
+                              padding: const EdgeInsets.fromLTRB(5, 0, 0, 0),
+                              child: Text(
+                                  "Last taken today at : ${dateService.getHourFromDate(lastTaken)}",
+                                  style: TextStyle(
+                                      fontSize: 20.0,
+                                      fontWeight: FontWeight.bold)))
+                        ]
+                      : [])
             ])),
       ),
     );

--- a/lib/widget/pill_to_take_widget.dart
+++ b/lib/widget/pill_to_take_widget.dart
@@ -63,9 +63,13 @@ class PillWidget extends StatelessWidget {
                   children: lastTaken != null
                       ? [
                           Icon(Icons.access_time),
-                          Text(dateService.getHourFromDate(lastTaken),
+                          Padding(
+                              padding: const EdgeInsets.fromLTRB(5, 0, 0, 0),
+                              child: Text(
+                              "Last taken today at : ${dateService.getHourFromDate(lastTaken)}",
                               style: TextStyle(
                                   fontSize: 20.0, fontWeight: FontWeight.bold))
+                          )
                         ]
                       : [])
             ])),

--- a/lib/widget/pill_to_take_widget.dart
+++ b/lib/widget/pill_to_take_widget.dart
@@ -24,6 +24,8 @@ class PillWidget extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    DateTime? lastTaken = pillToTake.lastTaken;
+
     return Container(
       child: Card(
         child: InkWell(
@@ -58,12 +60,10 @@ class PillWidget extends StatelessWidget {
               ),
               Row(
                   mainAxisAlignment: MainAxisAlignment.center,
-                  children: pillToTake.lastTaken != null
+                  children: lastTaken != null
                       ? [
                           Icon(Icons.access_time),
-                          Text(
-                              dateService
-                                  .getHourFromDate(pillToTake.lastTaken!),
+                          Text(dateService.getHourFromDate(lastTaken),
                               style: TextStyle(
                                   fontSize: 20.0, fontWeight: FontWeight.bold))
                         ]


### PR DESCRIPTION
Resolves #44 

This pull request refactors the display logic for the "last taken" pill information in two widgets, improving code readability and consistency. The changes ensure that the `lastTaken` property is checked and displayed in a more streamlined manner, with added null safety and formatted text.

### Refactoring for "last taken" pill information:

* **`PillTakenWidget` (`lib/widget/pill_taken_widget.dart`)**:
  - Introduced a local variable `lastTaken` to store `pillToTake.lastTaken`, improving readability and avoiding repeated null checks.
  - Updated the `Row` widget to conditionally display the "last taken" time with improved formatting, using a `Padding` widget for spacing and a more user-friendly text format.

* **`PillWidget` (`lib/widget/pill_to_take_widget.dart`)**:
  - Similarly, introduced a local variable `lastTaken` for better readability and null safety.
  - Refactored the conditional rendering of the "last taken" time, aligning it with the changes in `PillTakenWidget` for consistency.