### PR TITLE
Pill replacing usage of context.read

### DIFF
--- a/lib/page/settings_page.dart
+++ b/lib/page/settings_page.dart
@@ -22,9 +22,9 @@ class SettingsPage extends StatelessWidget {
                       : const Color(0xFF642ef3)),
               value: themeMode == ThemeMode.dark,
               onChanged: (bool isDarkModeEnabled) {
-                ThemeEvent event = themeMode == ThemeMode.dark
-                    ? ThemeEvent.enableLightMode
-                    : ThemeEvent.enableDarkMode;
+                ThemeEvent event = isDarkModeEnabled
+                    ? ThemeEvent.enableDarkMode
+                    : ThemeEvent.enableLightMode;
                 context.read<ThemeBloc>().add(event);
               });
         },

--- a/lib/page/settings_page.dart
+++ b/lib/page/settings_page.dart
@@ -12,38 +12,41 @@ class SettingsPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Column(mainAxisAlignment: MainAxisAlignment.start, children: [
-      SwitchListTile(
-          title: const Text("Dark Mode"),
-          secondary: Icon(Icons.dark_mode,
-              color: _getThemeColorForDarkModeSetting(context)),
-          value:
-              context.read<ThemeBloc>().state == ThemeMode.dark ? true : false,
-          onChanged: (bool isDarkModeEnabled) {
-            ThemeEvent event = context.read<ThemeBloc>().state == ThemeMode.dark
-                ? ThemeEvent.enableLightMode
-                : ThemeEvent.enableDarkMode;
-            BlocProvider.of<ThemeBloc>(context).add(event);
-          }),
-      ListTile(
-          title: const Text("Clear All Pills"),
-          leading: const Icon(Icons.clear, color: Colors.redAccent),
-          enabled: context.read<ClearPillsBloc>().state,
-          onTap: () {
-            AlertDialog alertDialog = _createClearAllPillsAlertDialog(context);
-            showDialog(
-                context: context,
-                builder: (BuildContext context) {
-                  return alertDialog;
-                });
-          }),
+      BlocBuilder<ThemeBloc, ThemeMode>(
+        builder: (context, themeMode) {
+          return SwitchListTile(
+              title: const Text("Dark Mode"),
+              secondary: Icon(Icons.dark_mode,
+                  color: themeMode == ThemeMode.dark
+                      ? const Color.fromARGB(200, 243, 231, 106)
+                      : const Color(0xFF642ef3)),
+              value: themeMode == ThemeMode.dark,
+              onChanged: (bool isDarkModeEnabled) {
+                ThemeEvent event = themeMode == ThemeMode.dark
+                    ? ThemeEvent.enableLightMode
+                    : ThemeEvent.enableDarkMode;
+                context.read<ThemeBloc>().add(event);
+              });
+        },
+      ),
+      BlocBuilder<ClearPillsBloc, bool>(
+        builder: (context, clearPillsEnabled) {
+          return ListTile(
+              title: const Text("Clear All Pills"),
+              leading: const Icon(Icons.clear, color: Colors.redAccent),
+              enabled: clearPillsEnabled,
+              onTap: () {
+                AlertDialog alertDialog = _createClearAllPillsAlertDialog(context);
+                showDialog(
+                    context: context,
+                    builder: (BuildContext context) {
+                      return alertDialog;
+                    });
+              });
+        },
+      ),
     ]);
   }
-}
-
-Color _getThemeColorForDarkModeSetting(BuildContext context) {
-  return context.read<ThemeBloc>().state == ThemeMode.dark
-      ? const Color.fromARGB(200, 243, 231, 106)
-      : const Color(0xFF642ef3);
 }
 
 AlertDialog _createClearAllPillsAlertDialog(BuildContext context) {


### PR DESCRIPTION
Fixes #74 

This pull request refactors the `SettingsPage` to use `BlocBuilder` widgets for improved state management and UI reactivity. The most important changes are:

**State Management Improvements:**

* Replaced direct `Bloc` state reads with `BlocBuilder<ThemeBloc, ThemeMode>` for the Dark Mode `SwitchListTile`, ensuring the UI updates automatically when the theme changes.
* Replaced direct `Bloc` state reads with `BlocBuilder<ClearPillsBloc, bool>` for the Clear All Pills `ListTile`, so the enabled state is always in sync with the bloc.

**Code Simplification:**

* Removed the `_getThemeColorForDarkModeSetting` helper function, inlining the color logic directly into the widget builder for clarity and maintainability.