### PR TITLE
Feature/date format

### DIFF
--- a/lib/bloc/pill/pill_bloc.dart
+++ b/lib/bloc/pill/pill_bloc.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:pill/model/pill_taken.dart';
+import 'package:pill/service/date_service.dart';
 import 'package:pill/service/shared_preferences_service.dart';
 import 'package:pill/bloc/pill/pill_state.dart';
 import 'package:pill/model/pill_to_take.dart';
@@ -29,43 +30,45 @@ class PillsEvent {
 }
 
 class PillBloc extends Bloc<PillsEvent, PillState> {
-  PillBloc(SharedPreferencesService sharedPreferencesService)
+  final SharedPreferencesService _sharedPreferencesService;
+  final DateService _dateService;
+
+  PillBloc(this._sharedPreferencesService, this._dateService)
       : super(PillState()) {
     on<PillsEvent>((event, emit) {
       switch (event.eventName) {
         case PillEvent.addPill:
-          _onAddPill(event, emit, sharedPreferencesService);
+          _onAddPill(event, emit);
           break;
         case PillEvent.removePill:
-          _onRemovePill(event, emit, sharedPreferencesService);
+          _onRemovePill(event, emit);
           break;
         case PillEvent.updatePill:
-          _onUpdatePill(event, emit, sharedPreferencesService);
+          _onUpdatePill(event, emit);
           break;
         case PillEvent.loadPills:
           final pillsTaken =
-              sharedPreferencesService.getPillsTakenForDate(event.date);
+              _sharedPreferencesService.getPillsTakenForDate(event.date);
           final pillsToTake =
-              sharedPreferencesService.getPillsToTakeForDate(event.date);
+              _sharedPreferencesService.getPillsToTakeForDate(event.date);
           emit(PillState(pillsToTake: pillsToTake, pillsTaken: pillsTaken));
           break;
       }
     });
   }
 
-  void _onAddPill(PillsEvent event, Emitter<PillState> emitter,
-      SharedPreferencesService sharedPreferencesService) {
+  void _onAddPill(PillsEvent event, Emitter<PillState> emitter) {
     final pillToTake = event.pillToTake;
     if (pillToTake == null) return;
 
     // addPillToDates writes to all scheduled dates. We then read back
     // event.date specifically so the emitted state always reflects the
     // correct day's list, regardless of how many days the pill spans.
-    sharedPreferencesService.addPillToDates(
-        event.startDateTime ?? DateTime.now(), pillToTake);
+    _sharedPreferencesService.addPillToDates(
+        event.startDateTime ?? _dateService.now(), pillToTake);
 
     final pillsToTake =
-        sharedPreferencesService.getPillsToTakeForDate(event.date);
+        _sharedPreferencesService.getPillsToTakeForDate(event.date);
 
     emitter(PillState(
       pillsToTake: pillsToTake,
@@ -73,13 +76,12 @@ class PillBloc extends Bloc<PillsEvent, PillState> {
     ));
   }
 
-  void _onRemovePill(PillsEvent event, Emitter<PillState> emitter,
-      SharedPreferencesService sharedPreferencesService) {
+  void _onRemovePill(PillsEvent event, Emitter<PillState> emitter) {
     final pillToTake = event.pillToTake;
     if (pillToTake == null) return;
 
     final updatedPills =
-        sharedPreferencesService.removePillFromDate(pillToTake, event.date);
+        _sharedPreferencesService.removePillFromDate(pillToTake, event.date);
 
     emitter(PillState(
       pillsToTake: updatedPills,
@@ -87,13 +89,12 @@ class PillBloc extends Bloc<PillsEvent, PillState> {
     ));
   }
 
-  void _onUpdatePill(PillsEvent event, Emitter<PillState> emitter,
-      SharedPreferencesService sharedPreferencesService) {
+  void _onUpdatePill(PillsEvent event, Emitter<PillState> emitter) {
     final pillToTake = event.pillToTake;
     if (pillToTake == null) return;
 
     final result =
-        sharedPreferencesService.updatePillForDate(pillToTake, event.date);
+        _sharedPreferencesService.updatePillForDate(pillToTake, event.date);
 
     if (result == null) return;
 

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -25,3 +25,4 @@ const String pillsTakenHeader = "You have not taken any pills today";
 const String pillsTakenKey = "pillsTaken";
 const String timeAppOpenedKey = "timeAppOpened";
 const String darkModeKey = "darkMode";
+const String migratedToYearlyKeysKey = "migratedToYearlyKeys";

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -36,7 +36,7 @@ class MyApp extends StatelessWidget {
     return MultiBlocProvider(
       providers: [
         BlocProvider(
-          create: (context) => PillBloc(sharedPreferencesService),
+          create: (context) => PillBloc(sharedPreferencesService, dateService),
         ),
         BlocProvider(
             create: (context) =>

--- a/lib/model/pill_taken.dart
+++ b/lib/model/pill_taken.dart
@@ -65,6 +65,22 @@ class PillTaken extends Equatable {
           .map<PillTaken>((pill) => PillTaken.fromJson(pill))
           .toList();
 
+  PillTaken copyWith({
+    String? pillName,
+    String? pillImage,
+    String? description,
+    DateTime? lastTaken,
+    bool clearDescription = false,
+    bool clearLastTaken = false,
+  }) {
+    return PillTaken(
+      pillName: pillName ?? this.pillName,
+      pillImage: pillImage ?? this.pillImage,
+      description: clearDescription ? null : (description ?? this.description),
+      lastTaken: clearLastTaken ? null : (lastTaken ?? this.lastTaken),
+    );
+  }
+
   @override
   List<Object?> get props => [pillName, pillImage, description, lastTaken];
 }

--- a/lib/page/main_page.dart
+++ b/lib/page/main_page.dart
@@ -156,7 +156,7 @@ class _MainPageState extends State<MainPage> with WidgetsBindingObserver {
                             borderRadius:
                                 BorderRadius.vertical(top: Radius.circular(20)),
                           ),
-                          builder: (context) => const AddingPillForm());
+                          builder: (context) => AddingPillForm(pillDate: _now));
                     },
                     child: const Icon(Icons.add));
               }),

--- a/lib/page/main_page.dart
+++ b/lib/page/main_page.dart
@@ -29,17 +29,36 @@ class MainPage extends StatefulWidget {
   State<MainPage> createState() => _MainPageState();
 }
 
-class _MainPageState extends State<MainPage> {
+class _MainPageState extends State<MainPage> with WidgetsBindingObserver {
   late DateTime _now;
 
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addObserver(this);
     _now = DateTime.now();
-    BlocProvider.of<PillBloc>(context).add(PillsEvent(
+    _loadPillsForToday();
+    widget.sharedPreferencesService.clearPillsOfPastDays();
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed) {
+      _updateNow();
+      _loadPillsForToday();
+    }
+  }
+
+  void _loadPillsForToday() {
+    context.read<PillBloc>().add(PillsEvent(
         eventName: PillEvent.loadPills,
         date: widget.dateService.formatDateForStorage(_now)));
-    widget.sharedPreferencesService.clearPillsOfPastDays();
   }
 
   void _updateNow() {
@@ -76,9 +95,7 @@ class _MainPageState extends State<MainPage> {
             switch (tabIndex) {
               case pillsToTakeTabIndex:
               case pillsTakenTabIndex:
-                context.read<PillBloc>().add(PillsEvent(
-                    eventName: PillEvent.loadPills,
-                    date: dateService.formatDateForStorage(_now)));
+                _loadPillsForToday();
                 break;
               case settingsTabIndex:
                 context
@@ -108,6 +125,7 @@ class _MainPageState extends State<MainPage> {
               child: Builder(builder: (context) {
                 return FloatingActionButton(
                     onPressed: () {
+                      _updateNow();
                       showModalBottomSheet(
                           context: context,
                           isScrollControlled: true,

--- a/lib/page/main_page.dart
+++ b/lib/page/main_page.dart
@@ -158,7 +158,10 @@ class _MainPageState extends State<MainPage> with WidgetsBindingObserver {
                                 BorderRadius.vertical(top: Radius.circular(20)),
                           ),
                           builder: (context) => AddingPillForm(
-                              pillDate: _now, dateService: widget.dateService));
+                              pillDate: _now,
+                              sharedPreferencesService:
+                                  widget.sharedPreferencesService,
+                              dateService: widget.dateService));
                     },
                     child: const Icon(Icons.add));
               }),

--- a/lib/page/main_page.dart
+++ b/lib/page/main_page.dart
@@ -35,7 +35,7 @@ class _MainPageState extends State<MainPage> {
     super.initState();
     BlocProvider.of<PillBloc>(context).add(PillsEvent(
         eventName: PillEvent.loadPills,
-        date: widget.dateService.getCurrentDateAsYearMonthDay()));
+        date: widget.dateService.formatDateForStorage(DateTime.now())));
     widget.sharedPreferencesService.clearPillsOfPastDays();
   }
 
@@ -69,7 +69,7 @@ PreferredSizeWidget _mainPageAppBar(
             case pillsTakenTabIndex:
               context.read<PillBloc>().add(PillsEvent(
                   eventName: PillEvent.loadPills,
-                  date: dateService.getCurrentDateAsYearMonthDay()));
+                  date: dateService.formatDateForStorage(DateTime.now())));
               break;
             case settingsTabIndex:
               context

--- a/lib/page/main_page.dart
+++ b/lib/page/main_page.dart
@@ -55,6 +55,7 @@ class _MainPageState extends State<MainPage> with WidgetsBindingObserver {
   void didChangeAppLifecycleState(AppLifecycleState state) {
     if (state == AppLifecycleState.resumed) {
       _loadPillsForToday();
+      _scheduleMidnightRefresh();
     }
   }
 

--- a/lib/page/main_page.dart
+++ b/lib/page/main_page.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:pill/bloc/clearPills/clear_pills_bloc.dart';
@@ -31,6 +32,7 @@ class MainPage extends StatefulWidget {
 
 class _MainPageState extends State<MainPage> with WidgetsBindingObserver {
   late DateTime _now;
+  Timer? _midnightTimer;
 
   @override
   void initState() {
@@ -39,26 +41,52 @@ class _MainPageState extends State<MainPage> with WidgetsBindingObserver {
     _now = DateTime.now();
     _loadPillsForToday();
     widget.sharedPreferencesService.clearPillsOfPastDays();
+    _scheduleMidnightRefresh();
   }
 
   @override
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
+    _midnightTimer?.cancel();
     super.dispose();
   }
 
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
     if (state == AppLifecycleState.resumed) {
-      _updateNow();
       _loadPillsForToday();
     }
   }
 
+  void _scheduleMidnightRefresh() {
+    _midnightTimer?.cancel();
+    final now = DateTime.now();
+    final nextMidnight = DateTime(now.year, now.month, now.day + 1);
+    final duration = nextMidnight.difference(now);
+
+    // Add a 1-second buffer to ensure we've crossed the boundary
+    _midnightTimer = Timer(duration + const Duration(seconds: 1), () {
+      if (mounted) {
+        _loadPillsForToday();
+        _scheduleMidnightRefresh();
+      }
+    });
+  }
+
   void _loadPillsForToday() {
+    final now = DateTime.now();
+    final todayStr = widget.dateService.formatDateForStorage(now);
+    final displayedStr = widget.dateService.formatDateForStorage(_now);
+
+    if (todayStr != displayedStr) {
+      setState(() {
+        _now = now;
+      });
+    }
+
     context.read<PillBloc>().add(PillsEvent(
         eventName: PillEvent.loadPills,
-        date: widget.dateService.formatDateForStorage(_now)));
+        date: todayStr));
   }
 
   void _updateNow() {
@@ -91,13 +119,13 @@ class _MainPageState extends State<MainPage> with WidgetsBindingObserver {
             Tab(icon: Icon(Icons.settings)),
           ],
           onTap: (tabIndex) {
-            _updateNow();
             switch (tabIndex) {
               case pillsToTakeTabIndex:
               case pillsTakenTabIndex:
                 _loadPillsForToday();
                 break;
               case settingsTabIndex:
+                _updateNow();
                 context
                     .read<ClearPillsBloc>()
                     .add(ClearPillsEvent.updatePillsStatus);
@@ -133,7 +161,7 @@ class _MainPageState extends State<MainPage> with WidgetsBindingObserver {
                             borderRadius:
                                 BorderRadius.vertical(top: Radius.circular(20)),
                           ),
-                          builder: (context) => AddingPillForm(_now));
+                          builder: (context) => const AddingPillForm());
                     },
                     child: const Icon(Icons.add));
               }),

--- a/lib/page/main_page.dart
+++ b/lib/page/main_page.dart
@@ -38,7 +38,7 @@ class _MainPageState extends State<MainPage> with WidgetsBindingObserver {
   void initState() {
     super.initState();
     WidgetsBinding.instance.addObserver(this);
-    _now = DateTime.now();
+    _now = widget.dateService.now();
     _loadPillsForToday();
     widget.sharedPreferencesService.clearPillsOfPastDays();
     _scheduleMidnightRefresh();
@@ -60,7 +60,7 @@ class _MainPageState extends State<MainPage> with WidgetsBindingObserver {
 
   void _scheduleMidnightRefresh() {
     _midnightTimer?.cancel();
-    final now = DateTime.now();
+    final now = widget.dateService.now();
     final nextMidnight = DateTime(now.year, now.month, now.day + 1);
     final duration = nextMidnight.difference(now);
 
@@ -74,7 +74,7 @@ class _MainPageState extends State<MainPage> with WidgetsBindingObserver {
   }
 
   void _loadPillsForToday() {
-    final now = DateTime.now();
+    final now = widget.dateService.now();
     final todayStr = widget.dateService.formatDateForStorage(now);
     final displayedStr = widget.dateService.formatDateForStorage(_now);
 
@@ -91,7 +91,7 @@ class _MainPageState extends State<MainPage> with WidgetsBindingObserver {
 
   void _updateNow() {
     setState(() {
-      _now = DateTime.now();
+      _now = widget.dateService.now();
     });
   }
 
@@ -156,7 +156,8 @@ class _MainPageState extends State<MainPage> with WidgetsBindingObserver {
                             borderRadius:
                                 BorderRadius.vertical(top: Radius.circular(20)),
                           ),
-                          builder: (context) => AddingPillForm(pillDate: _now));
+                          builder: (context) => AddingPillForm(
+                              pillDate: _now, dateService: widget.dateService));
                     },
                     child: const Icon(Icons.add));
               }),

--- a/lib/page/main_page.dart
+++ b/lib/page/main_page.dart
@@ -30,13 +30,22 @@ class MainPage extends StatefulWidget {
 }
 
 class _MainPageState extends State<MainPage> {
+  late DateTime _now;
+
   @override
   void initState() {
     super.initState();
+    _now = DateTime.now();
     BlocProvider.of<PillBloc>(context).add(PillsEvent(
         eventName: PillEvent.loadPills,
-        date: widget.dateService.formatDateForStorage(DateTime.now())));
+        date: widget.dateService.formatDateForStorage(_now)));
     widget.sharedPreferencesService.clearPillsOfPastDays();
+  }
+
+  void _updateNow() {
+    setState(() {
+      _now = DateTime.now();
+    });
   }
 
   @override
@@ -48,80 +57,81 @@ class _MainPageState extends State<MainPage> {
             body: _mainPageTabBarView(
                 widget.dateService, widget.sharedPreferencesService)));
   }
-}
 
-PreferredSizeWidget _mainPageAppBar(
-  BuildContext context,
-  DateService dateService,
-) {
-  return PreferredSize(
-    preferredSize: const Size.fromHeight(50),
-    child: AppBar(
-      bottom: TabBar(
-        tabs: const [
-          Tab(icon: Icon(CustomIcons.pill)),
-          Tab(icon: Icon(Icons.watch_later_rounded)),
-          Tab(icon: Icon(Icons.settings)),
-        ],
-        onTap: (tabIndex) {
-          switch (tabIndex) {
-            case pillsToTakeTabIndex:
-            case pillsTakenTabIndex:
-              context.read<PillBloc>().add(PillsEvent(
-                  eventName: PillEvent.loadPills,
-                  date: dateService.formatDateForStorage(DateTime.now())));
-              break;
-            case settingsTabIndex:
-              context
-                  .read<ClearPillsBloc>()
-                  .add(ClearPillsEvent.updatePillsStatus);
-          }
-        },
+  PreferredSizeWidget _mainPageAppBar(
+    BuildContext context,
+    DateService dateService,
+  ) {
+    return PreferredSize(
+      preferredSize: const Size.fromHeight(50),
+      child: AppBar(
+        bottom: TabBar(
+          tabs: const [
+            Tab(icon: Icon(CustomIcons.pill)),
+            Tab(icon: Icon(Icons.watch_later_rounded)),
+            Tab(icon: Icon(Icons.settings)),
+          ],
+          onTap: (tabIndex) {
+            _updateNow();
+            switch (tabIndex) {
+              case pillsToTakeTabIndex:
+              case pillsTakenTabIndex:
+                context.read<PillBloc>().add(PillsEvent(
+                    eventName: PillEvent.loadPills,
+                    date: dateService.formatDateForStorage(_now)));
+                break;
+              case settingsTabIndex:
+                context
+                    .read<ClearPillsBloc>()
+                    .add(ClearPillsEvent.updatePillsStatus);
+            }
+          },
+        ),
       ),
-    ),
-  );
-}
+    );
+  }
 
-TabBarView _mainPageTabBarView(DateService dateService,
-    SharedPreferencesService sharedPreferencesService) {
-  return TabBarView(children: [
-    Column(
-      mainAxisAlignment: MainAxisAlignment.start,
-      children: <Widget>[
+  TabBarView _mainPageTabBarView(DateService dateService,
+      SharedPreferencesService sharedPreferencesService) {
+    return TabBarView(children: [
+      Column(
+        mainAxisAlignment: MainAxisAlignment.start,
+        children: <Widget>[
+          DayWidget(
+              date: _now,
+              mode: DayWidgetMode.toTake,
+              dateService: dateService),
+          Align(
+            alignment: Alignment.bottomRight,
+            child: Padding(
+              padding: const EdgeInsets.all(10.0),
+              child: Builder(builder: (context) {
+                return FloatingActionButton(
+                    onPressed: () {
+                      showModalBottomSheet(
+                          context: context,
+                          isScrollControlled: true,
+                          shape: const RoundedRectangleBorder(
+                            borderRadius:
+                                BorderRadius.vertical(top: Radius.circular(20)),
+                          ),
+                          builder: (context) => AddingPillForm(_now));
+                    },
+                    child: const Icon(Icons.add));
+              }),
+            ),
+          )
+        ],
+      ),
+      Column(mainAxisAlignment: MainAxisAlignment.start, children: <Widget>[
         DayWidget(
-            date: DateTime.now(),
-            mode: DayWidgetMode.toTake,
+            date: _now,
+            mode: DayWidgetMode.taken,
             dateService: dateService),
-        Align(
-          alignment: Alignment.bottomRight,
-          child: Padding(
-            padding: const EdgeInsets.all(10.0),
-            child: Builder(builder: (context) {
-              return FloatingActionButton(
-                  onPressed: () {
-                    showModalBottomSheet(
-                        context: context,
-                        isScrollControlled: true,
-                        shape: const RoundedRectangleBorder(
-                          borderRadius:
-                              BorderRadius.vertical(top: Radius.circular(20)),
-                        ),
-                        builder: (context) => AddingPillForm(DateTime.now()));
-                  },
-                  child: const Icon(Icons.add));
-            }),
-          ),
-        )
-      ],
-    ),
-    Column(mainAxisAlignment: MainAxisAlignment.start, children: <Widget>[
-      DayWidget(
-          date: DateTime.now(),
-          mode: DayWidgetMode.taken,
-          dateService: dateService),
-    ]),
-    BlocBuilder<ClearPillsBloc, bool>(builder: (context, state) {
-      return SettingsPage(sharedPreferencesService: sharedPreferencesService);
-    })
-  ]);
+      ]),
+      BlocBuilder<ClearPillsBloc, bool>(builder: (context, state) {
+        return SettingsPage(sharedPreferencesService: sharedPreferencesService);
+      })
+    ]);
+  }
 }

--- a/lib/page/main_page.dart
+++ b/lib/page/main_page.dart
@@ -100,15 +100,11 @@ class _MainPageState extends State<MainPage> with WidgetsBindingObserver {
     return DefaultTabController(
         length: amountOfTabs,
         child: Scaffold(
-            appBar: _mainPageAppBar(context, widget.dateService),
-            body: _mainPageTabBarView(
-                widget.dateService, widget.sharedPreferencesService)));
+            appBar: _mainPageAppBar(context),
+            body: _mainPageTabBarView()));
   }
 
-  PreferredSizeWidget _mainPageAppBar(
-    BuildContext context,
-    DateService dateService,
-  ) {
+  PreferredSizeWidget _mainPageAppBar(BuildContext context) {
     return PreferredSize(
       preferredSize: const Size.fromHeight(50),
       child: AppBar(
@@ -136,8 +132,7 @@ class _MainPageState extends State<MainPage> with WidgetsBindingObserver {
     );
   }
 
-  TabBarView _mainPageTabBarView(DateService dateService,
-      SharedPreferencesService sharedPreferencesService) {
+  TabBarView _mainPageTabBarView() {
     return TabBarView(children: [
       Column(
         mainAxisAlignment: MainAxisAlignment.start,
@@ -145,7 +140,7 @@ class _MainPageState extends State<MainPage> with WidgetsBindingObserver {
           DayWidget(
               date: _now,
               mode: DayWidgetMode.toTake,
-              dateService: dateService),
+              dateService: widget.dateService),
           Align(
             alignment: Alignment.bottomRight,
             child: Padding(
@@ -173,10 +168,11 @@ class _MainPageState extends State<MainPage> with WidgetsBindingObserver {
         DayWidget(
             date: _now,
             mode: DayWidgetMode.taken,
-            dateService: dateService),
+            dateService: widget.dateService),
       ]),
       BlocBuilder<ClearPillsBloc, bool>(builder: (context, state) {
-        return SettingsPage(sharedPreferencesService: sharedPreferencesService);
+        return SettingsPage(
+            sharedPreferencesService: widget.sharedPreferencesService);
       })
     ]);
   }

--- a/lib/page/main_page.dart
+++ b/lib/page/main_page.dart
@@ -35,7 +35,7 @@ class _MainPageState extends State<MainPage> {
     super.initState();
     BlocProvider.of<PillBloc>(context).add(PillsEvent(
         eventName: PillEvent.loadPills,
-        date: widget.dateService.getCurrentDateAsMonthAndDay()));
+        date: widget.dateService.getCurrentDateAsYearMonthDay()));
     widget.sharedPreferencesService.clearPillsOfPastDays();
   }
 
@@ -69,7 +69,7 @@ PreferredSizeWidget _mainPageAppBar(
             case pillsTakenTabIndex:
               context.read<PillBloc>().add(PillsEvent(
                   eventName: PillEvent.loadPills,
-                  date: dateService.getCurrentDateAsMonthAndDay()));
+                  date: dateService.getCurrentDateAsYearMonthDay()));
               break;
             case settingsTabIndex:
               context

--- a/lib/service/date_service.dart
+++ b/lib/service/date_service.dart
@@ -1,6 +1,9 @@
 const int ten = 10;
 
 class DateService {
+  /// Returns the current date and time.
+  DateTime now() => DateTime.now();
+
   /// Returns a date string formatted as "YYYY/M/D", suitable for storage keys.
   String formatDateForStorage(DateTime date) {
     return "${date.year}/${date.month}/${date.day}";
@@ -23,9 +26,9 @@ class DateService {
     return digit < ten ? "0$digit" : "$digit";
   }
 
-  @Deprecated('Use formatDateForStorage(DateTime.now())')
+  @Deprecated('Use formatDateForStorage(dateService.now())')
   String getCurrentDateAsYearMonthDay() {
-    return formatDateForStorage(DateTime.now());
+    return formatDateForStorage(now());
   }
 
   @Deprecated('Use formatDateForStorage or formatDateForDisplay')

--- a/lib/service/date_service.dart
+++ b/lib/service/date_service.dart
@@ -1,8 +1,14 @@
 const int ten = 10;
 
 class DateService {
-  String getDateAsYearMonthDay(DateTime date) {
+  /// Returns a date string formatted as "YYYY/M/D", suitable for storage keys.
+  String formatDateForStorage(DateTime date) {
     return "${date.year}/${date.month}/${date.day}";
+  }
+
+  /// Returns a date string formatted as "M/D" for user-facing display.
+  String formatDateForDisplay(DateTime date) {
+    return "${date.month}/${date.day}";
   }
 
   String getHourFromDate(DateTime dateTime) {
@@ -17,7 +23,13 @@ class DateService {
     return digit < ten ? "0$digit" : "$digit";
   }
 
+  @Deprecated('Use formatDateForStorage(DateTime.now())')
   String getCurrentDateAsYearMonthDay() {
-    return getDateAsYearMonthDay(DateTime.now());
+    return formatDateForStorage(DateTime.now());
+  }
+
+  @Deprecated('Use formatDateForStorage or formatDateForDisplay')
+  String getDateAsYearMonthDay(DateTime date) {
+    return formatDateForStorage(date);
   }
 }

--- a/lib/service/date_service.dart
+++ b/lib/service/date_service.dart
@@ -1,7 +1,7 @@
 const int ten = 10;
 
 class DateService {
-  String getDateAsMonthAndDay(DateTime date) {
+  String getDateAsYearMonthDay(DateTime date) {
     return "${date.year}/${date.month}/${date.day}";
   }
 
@@ -17,7 +17,7 @@ class DateService {
     return digit < ten ? "0$digit" : "$digit";
   }
 
-  String getCurrentDateAsMonthAndDay() {
-    return getDateAsMonthAndDay(DateTime.now());
+  String getCurrentDateAsYearMonthDay() {
+    return getDateAsYearMonthDay(DateTime.now());
   }
 }

--- a/lib/service/date_service.dart
+++ b/lib/service/date_service.dart
@@ -2,7 +2,7 @@ const int ten = 10;
 
 class DateService {
   String getDateAsMonthAndDay(DateTime date) {
-    return "${date.month}/${date.day}";
+    return "${date.year}/${date.month}/${date.day}";
   }
 
   String getHourFromDate(DateTime dateTime) {

--- a/lib/service/shared_preferences_service.dart
+++ b/lib/service/shared_preferences_service.dart
@@ -47,7 +47,7 @@ class SharedPreferencesService {
       return;
     }
 
-    final keys = _sharedPreferences.getKeys();
+    final keys = _sharedPreferences.getKeys().toList();
     final currentYear = migrationYear ?? _dateService.now().year;
     bool allSucceeded = true;
 
@@ -279,7 +279,7 @@ class SharedPreferencesService {
   }
 
   void clearAllPills() {
-    Set<String> keys = _sharedPreferences.getKeys();
+    final keys = _sharedPreferences.getKeys().toList();
     for (String key in keys) {
       if (key == timeAppOpenedKey ||
           key == darkModeKey ||

--- a/lib/service/shared_preferences_service.dart
+++ b/lib/service/shared_preferences_service.dart
@@ -61,44 +61,50 @@ class SharedPreferencesService {
         final existingYearlyValue = _sharedPreferences.getString(migratedKey);
 
         if (legacyValue != null) {
-          String migratedValue = legacyValue;
-
-          if (existingYearlyValue != null) {
-            try {
-              if (key.startsWith(pillsTakenKey)) {
-                final legacyMonthlyPills = PillTaken.decode(legacyValue);
-                final existingYearlyPills = PillTaken.decode(existingYearlyValue);
+          try {
+            String migratedValue;
+            if (key.startsWith(pillsTakenKey)) {
+              final legacyPills = PillTaken.decode(legacyValue);
+              if (existingYearlyValue != null) {
+                final existingPills = PillTaken.decode(existingYearlyValue);
                 // For taken pills, combine and deduplicate exact matches
-                final merged =
-                    {...legacyMonthlyPills, ...existingYearlyPills}.toList();
+                final merged = {...legacyPills, ...existingPills}.toList();
                 migratedValue = PillTaken.encode(merged);
               } else {
-                final legacyMonthlyPills = PillToTake.decode(legacyValue);
-                final existingYearlyPills = PillToTake.decode(existingYearlyValue);
+                migratedValue = PillTaken.encode(legacyPills);
+              }
+            } else {
+              final legacyPills = PillToTake.decode(legacyValue);
+              if (existingYearlyValue != null) {
+                final existingPills = PillToTake.decode(existingYearlyValue);
                 // For pills to take, prefer the newer ones if names match
                 final Map<String, PillToTake> mergedMap = {};
-                for (final pill in legacyMonthlyPills) {
-                  mergedMap[pill.pillName.toLowerCase()] = pill;
+                for (final pill in legacyPills) {
+                  mergedMap[pill.pillName.trim().toLowerCase()] = pill;
                 }
-                for (final pill in existingYearlyPills) {
-                  mergedMap[pill.pillName.toLowerCase()] = pill;
+                for (final pill in existingPills) {
+                  mergedMap[pill.pillName.trim().toLowerCase()] = pill;
                 }
                 migratedValue = PillToTake.encode(mergedMap.values.toList());
+              } else {
+                migratedValue = PillToTake.encode(legacyPills);
               }
-            } catch (_) {
-              // On error, prefer existing (newer) value to prevent data corruption
-              migratedValue = existingYearlyValue;
             }
-          }
 
-          final setSuccess =
-              await _sharedPreferences.setString(migratedKey, migratedValue);
-          if (setSuccess) {
-            final removeSuccess = await _sharedPreferences.remove(key);
-            if (!removeSuccess) {
+            final setSuccess =
+                await _sharedPreferences.setString(migratedKey, migratedValue);
+            if (setSuccess) {
+              final removeSuccess = await _sharedPreferences.remove(key);
+              if (!removeSuccess) {
+                allSucceeded = false;
+              }
+            } else {
               allSucceeded = false;
             }
-          } else {
+          } catch (_) {
+            // If decoding or merging fails, we don't remove the legacy key
+            // and don't overwrite the existing yearly value with potentially
+            // corrupted data.
             allSucceeded = false;
           }
         }

--- a/lib/service/shared_preferences_service.dart
+++ b/lib/service/shared_preferences_service.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:developer';
+import 'package:meta/meta.dart';
 import 'package:pill/model/pill_taken.dart';
 import 'package:pill/model/pill_to_take.dart';
 import 'package:pill/service/date_service.dart';
@@ -20,6 +21,7 @@ class SharedPreferencesService {
     return _createInternal(dateService);
   }
 
+  @visibleForTesting
   static Future<SharedPreferencesService> createForTesting(
       DateService dateService,
       {int? migrationYear}) async {

--- a/lib/service/shared_preferences_service.dart
+++ b/lib/service/shared_preferences_service.dart
@@ -58,76 +58,94 @@ class SharedPreferencesService {
         continue;
       }
 
-      String? migratedKey;
-      // Match "M/D" or "MM/DD" but NOT "YYYY/M/D"
-      // Old keys are "month/day", new keys are "year/month/day"
-      if (RegExp(r'^\d{1,2}/\d{1,2}$').hasMatch(key)) {
-        migratedKey = "$currentYear/$key";
-      } else if (key.startsWith(pillsTakenKey)) {
-        final datePart = key.substring(pillsTakenKey.length);
-        if (RegExp(r'^\d{1,2}/\d{1,2}$').hasMatch(datePart)) {
-          migratedKey = "$pillsTakenKey$currentYear/$datePart";
-        }
-      }
+      final legacyValue = _sharedPreferences.getString(key);
+      if (legacyValue == null) continue;
 
-      if (migratedKey != null) {
-        final legacyValue = _sharedPreferences.getString(key);
-        final existingYearlyValue = _sharedPreferences.getString(migratedKey);
+      try {
+        if (key.startsWith(pillsTakenKey)) {
+          final datePart = key.substring(pillsTakenKey.length);
+          // Match "M/D" or "MM/DD" but NOT "YYYY/M/D"
+          if (RegExp(r'^\d{1,2}/\d{1,2}$').hasMatch(datePart)) {
+            final legacyPills = PillTaken.decode(legacyValue);
+            final Map<int, List<PillTaken>> pillsByYear = {};
+            for (final pill in legacyPills) {
+              final year = pill.lastTaken?.year ?? currentYear;
+              pillsByYear.putIfAbsent(year, () => []).add(pill);
+            }
 
-        if (legacyValue != null) {
-          try {
-            String migratedValue;
-            if (key.startsWith(pillsTakenKey)) {
-              final legacyPills = PillTaken.decode(legacyValue);
+            bool currentKeyMigrationSucceeded = true;
+            for (final entry in pillsByYear.entries) {
+              final year = entry.key;
+              final pillsForYear = entry.value;
+              final targetKey = "$pillsTakenKey$year/$datePart";
+              final existingYearlyValue =
+                  _sharedPreferences.getString(targetKey);
+
+              String migratedValue;
               if (existingYearlyValue != null) {
                 final existingPills = PillTaken.decode(existingYearlyValue);
                 // For taken pills, combine and deduplicate exact matches
-                final merged = {...legacyPills, ...existingPills}.toList();
+                final merged = {...pillsForYear, ...existingPills}.toList();
                 migratedValue = PillTaken.encode(merged);
               } else {
-                migratedValue = PillTaken.encode(legacyPills);
+                migratedValue = PillTaken.encode(pillsForYear);
               }
-            } else {
-              final legacyPills = PillToTake.decode(legacyValue);
-              if (existingYearlyValue != null) {
-                final existingPills = PillToTake.decode(existingYearlyValue);
-                // For pills to take, prefer the newer ones if names match
-                final Map<String, PillToTake> mergedMap = {};
-                for (final pill in legacyPills) {
-                  mergedMap[pill.pillName.trim().toLowerCase()] = pill;
-                }
-                for (final pill in existingPills) {
-                  mergedMap[pill.pillName.trim().toLowerCase()] = pill;
-                }
-                migratedValue = PillToTake.encode(mergedMap.values.toList());
-              } else {
-                migratedValue = PillToTake.encode(legacyPills);
+
+              if (!(await _sharedPreferences.setString(
+                  targetKey, migratedValue))) {
+                log("Failed to write migrated value for key '$targetKey'",
+                    level: 1000);
+                currentKeyMigrationSucceeded = false;
               }
             }
 
-            final setSuccess =
-                await _sharedPreferences.setString(migratedKey, migratedValue);
-            if (setSuccess) {
-              final removeSuccess = await _sharedPreferences.remove(key);
-              if (!removeSuccess) {
-                log("Failed to remove legacy key '$key' after successful migration to '$migratedKey'",
+            if (currentKeyMigrationSucceeded) {
+              if (!(await _sharedPreferences.remove(key))) {
+                log("Failed to remove legacy key '$key' after successful migration",
                     level: 1000);
                 allSucceeded = false;
               }
             } else {
-              log("Failed to write migrated value for key '$migratedKey'",
+              allSucceeded = false;
+            }
+          }
+        } else if (RegExp(r'^\d{1,2}/\d{1,2}$').hasMatch(key)) {
+          // PillToTake key (legacy "M/D")
+          final targetKey = "$currentYear/$key";
+          final legacyPills = PillToTake.decode(legacyValue);
+          final existingYearlyValue = _sharedPreferences.getString(targetKey);
+
+          String migratedValue;
+          if (existingYearlyValue != null) {
+            final existingPills = PillToTake.decode(existingYearlyValue);
+            // For pills to take, prefer the newer ones if names match
+            final Map<String, PillToTake> mergedMap = {};
+            for (final pill in legacyPills) {
+              mergedMap[pill.pillName.trim().toLowerCase()] = pill;
+            }
+            for (final pill in existingPills) {
+              mergedMap[pill.pillName.trim().toLowerCase()] = pill;
+            }
+            migratedValue = PillToTake.encode(mergedMap.values.toList());
+          } else {
+            migratedValue = PillToTake.encode(legacyPills);
+          }
+
+          if (await _sharedPreferences.setString(targetKey, migratedValue)) {
+            if (!(await _sharedPreferences.remove(key))) {
+              log("Failed to remove legacy key '$key' after successful migration to '$targetKey'",
                   level: 1000);
               allSucceeded = false;
             }
-          } catch (e, st) {
-            log("Error migrating key '$key' to '$migratedKey': $e",
-                level: 1000, stackTrace: st);
-            // If decoding or merging fails, we don't remove the legacy key
-            // and don't overwrite the existing yearly value with potentially
-            // corrupted data.
+          } else {
+            log("Failed to write migrated value for key '$targetKey'",
+                level: 1000);
             allSucceeded = false;
           }
         }
+      } catch (e, st) {
+        log("Error migrating key '$key': $e", level: 1000, stackTrace: st);
+        allSucceeded = false;
       }
     }
 

--- a/lib/service/shared_preferences_service.dart
+++ b/lib/service/shared_preferences_service.dart
@@ -23,7 +23,49 @@ class SharedPreferencesService {
     sharedPreferencesService._sharedPreferences =
         await SharedPreferences.getInstance();
 
+    sharedPreferencesService._migrateKeys();
+
     return sharedPreferencesService;
+  }
+
+  void _migrateKeys() {
+    if (_sharedPreferences.getBool(migratedToYearlyKeysKey) ?? false) {
+      return;
+    }
+
+    final keys = _sharedPreferences.getKeys();
+    final currentYear = DateTime.now().year;
+
+    for (String key in keys) {
+      if (key == timeAppOpenedKey ||
+          key == darkModeKey ||
+          key == migratedToYearlyKeysKey) {
+        continue;
+      }
+
+      // Match "M/D" or "MM/DD" but NOT "YYYY/M/D"
+      // Old keys are "month/day", new keys are "year/month/day"
+      if (RegExp(r'^\d{1,2}/\d{1,2}$').hasMatch(key)) {
+        final value = _sharedPreferences.getString(key);
+        if (value != null) {
+          final newKey = "$currentYear/$key";
+          unawaited(_sharedPreferences.setString(newKey, value));
+          unawaited(_sharedPreferences.remove(key));
+        }
+      } else if (key.startsWith(pillsTakenKey)) {
+        final datePart = key.substring(pillsTakenKey.length);
+        if (RegExp(r'^\d{1,2}/\d{1,2}$').hasMatch(datePart)) {
+          final value = _sharedPreferences.getString(key);
+          if (value != null) {
+            final newKey = "$pillsTakenKey$currentYear/$datePart";
+            unawaited(_sharedPreferences.setString(newKey, value));
+            unawaited(_sharedPreferences.remove(key));
+          }
+        }
+      }
+    }
+
+    unawaited(_sharedPreferences.setBool(migratedToYearlyKeysKey, true));
   }
 
   // The Future returned by SharedPreferences write methods is intentionally
@@ -153,7 +195,9 @@ class SharedPreferencesService {
   void clearAllPills() {
     Set<String> keys = _sharedPreferences.getKeys();
     for (String key in keys) {
-      if (key.contains(timeAppOpenedKey)) {
+      if (key == timeAppOpenedKey ||
+          key == darkModeKey ||
+          key == migratedToYearlyKeysKey) {
         continue;
       }
       unawaited(_sharedPreferences.remove(key));

--- a/lib/service/shared_preferences_service.dart
+++ b/lib/service/shared_preferences_service.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:developer';
-import 'package:meta/meta.dart';
 import 'package:pill/model/pill_taken.dart';
 import 'package:pill/model/pill_to_take.dart';
 import 'package:pill/service/date_service.dart';
@@ -17,19 +16,14 @@ class SharedPreferencesService {
     _dateService = dateService;
   }
 
-  static Future<SharedPreferencesService> create(
-      DateService dateService) async {
-    return _createInternal(dateService);
-  }
-
-  @visibleForTesting
-  static Future<SharedPreferencesService> createForTesting(
-      DateService dateService, {int? migrationYear}) async {
+  static Future<SharedPreferencesService> create(DateService dateService,
+      {int? migrationYear}) async {
     return _createInternal(dateService, migrationYear: migrationYear);
   }
 
   static Future<SharedPreferencesService> _createInternal(
-      DateService dateService, {int? migrationYear}) async {
+      DateService dateService,
+      {int? migrationYear}) async {
     SharedPreferencesService sharedPreferencesService =
         SharedPreferencesService._create(dateService);
 

--- a/lib/service/shared_preferences_service.dart
+++ b/lib/service/shared_preferences_service.dart
@@ -171,7 +171,7 @@ class SharedPreferencesService {
     int daysToTake = pill.amountOfDaysToTake;
     final pillWithTrimmedName = pill.copyWith(pillName: pill.pillName.trim());
     while (daysToTake > 0) {
-      String dateStr = _dateService.getDateAsYearMonthDay(runningDate);
+      String dateStr = _dateService.formatDateForStorage(runningDate);
       List<PillToTake> pills = getPillsToTakeForDate(dateStr);
       pills.add(pillWithTrimmedName);
       _setPillsForDate(dateStr, pills);
@@ -236,7 +236,7 @@ class SharedPreferencesService {
     DateTime runningDate = dateToRemovePillsFrom;
 
     while (now.difference(runningDate).inDays >= oneDay) {
-      String converted = _dateService.getDateAsYearMonthDay(runningDate);
+      String converted = _dateService.formatDateForStorage(runningDate);
       _setPillsForDate(converted, []);
       _setPillsTakenForDate(converted, []);
       runningDate = runningDate.add(const Duration(days: oneDay));

--- a/lib/service/shared_preferences_service.dart
+++ b/lib/service/shared_preferences_service.dart
@@ -69,8 +69,10 @@ class SharedPreferencesService {
             final legacyPills = PillTaken.decode(legacyValue);
             final Map<int, List<PillTaken>> pillsByYear = {};
             for (final pill in legacyPills) {
-              final year = pill.lastTaken?.year ?? currentYear;
-              pillsByYear.putIfAbsent(year, () => []).add(pill);
+              final normalizedPill =
+                  pill.copyWith(pillName: pill.pillName.trim().toLowerCase());
+              final year = normalizedPill.lastTaken?.year ?? currentYear;
+              pillsByYear.putIfAbsent(year, () => []).add(normalizedPill);
             }
 
             bool currentKeyMigrationSucceeded = true;
@@ -85,7 +87,12 @@ class SharedPreferencesService {
               if (existingYearlyValue != null) {
                 final existingPills = PillTaken.decode(existingYearlyValue);
                 // For taken pills, combine and deduplicate exact matches
-                final merged = {...pillsForYear, ...existingPills}.toList();
+                // and normalize existing ones too
+                final normalizedExisting = existingPills
+                    .map((p) => p.copyWith(pillName: p.pillName.trim().toLowerCase()))
+                    .toList();
+                final merged =
+                    {...pillsForYear, ...normalizedExisting}.toList();
                 migratedValue = PillTaken.encode(merged);
               } else {
                 migratedValue = PillTaken.encode(pillsForYear);
@@ -112,19 +119,23 @@ class SharedPreferencesService {
         } else if (RegExp(r'^\d{1,2}/\d{1,2}$').hasMatch(key)) {
           // PillToTake key (legacy "M/D")
           final targetKey = "$currentYear/$key";
-          final legacyPills = PillToTake.decode(legacyValue);
+          final legacyPills = PillToTake.decode(legacyValue)
+              .map((p) => p.copyWith(pillName: p.pillName.trim().toLowerCase()))
+              .toList();
           final existingYearlyValue = _sharedPreferences.getString(targetKey);
 
           String migratedValue;
           if (existingYearlyValue != null) {
-            final existingPills = PillToTake.decode(existingYearlyValue);
+            final existingPills = PillToTake.decode(existingYearlyValue)
+                .map((p) => p.copyWith(pillName: p.pillName.trim().toLowerCase()))
+                .toList();
             // For pills to take, prefer the newer ones if names match
             final Map<String, PillToTake> mergedMap = {};
             for (final pill in legacyPills) {
-              mergedMap[pill.pillName.trim().toLowerCase()] = pill;
+              mergedMap[pill.pillName] = pill;
             }
             for (final pill in existingPills) {
-              mergedMap[pill.pillName.trim().toLowerCase()] = pill;
+              mergedMap[pill.pillName] = pill;
             }
             migratedValue = PillToTake.encode(mergedMap.values.toList());
           } else {
@@ -190,11 +201,11 @@ class SharedPreferencesService {
   void addPillToDates(DateTime startDate, PillToTake pill) {
     DateTime runningDate = startDate;
     int daysToTake = pill.amountOfDaysToTake;
-    final pillWithTrimmedName = pill.copyWith(pillName: pill.pillName.trim());
+    final pillWithNormalizedName = pill.copyWith(pillName: pill.pillName.trim().toLowerCase());
     while (daysToTake > 0) {
       String dateStr = _dateService.formatDateForStorage(runningDate);
       List<PillToTake> pills = getPillsToTakeForDate(dateStr);
-      pills.add(pillWithTrimmedName);
+      pills.add(pillWithNormalizedName);
       _setPillsForDate(dateStr, pills);
       runningDate = runningDate.add(const Duration(days: oneDay));
       daysToTake--;

--- a/lib/service/shared_preferences_service.dart
+++ b/lib/service/shared_preferences_service.dart
@@ -16,7 +16,12 @@ class SharedPreferencesService {
     _dateService = dateService;
   }
 
-  static Future<SharedPreferencesService> create(DateService dateService,
+  static Future<SharedPreferencesService> create(DateService dateService) async {
+    return _createInternal(dateService);
+  }
+
+  static Future<SharedPreferencesService> createForTesting(
+      DateService dateService,
       {int? migrationYear}) async {
     return _createInternal(dateService, migrationYear: migrationYear);
   }

--- a/lib/service/shared_preferences_service.dart
+++ b/lib/service/shared_preferences_service.dart
@@ -1,4 +1,6 @@
 import 'dart:async';
+import 'dart:developer';
+import 'package:meta/meta.dart';
 import 'package:pill/model/pill_taken.dart';
 import 'package:pill/model/pill_to_take.dart';
 import 'package:pill/service/date_service.dart';
@@ -16,6 +18,17 @@ class SharedPreferencesService {
   }
 
   static Future<SharedPreferencesService> create(
+      DateService dateService) async {
+    return _createInternal(dateService);
+  }
+
+  @visibleForTesting
+  static Future<SharedPreferencesService> createForTesting(
+      DateService dateService, {int? migrationYear}) async {
+    return _createInternal(dateService, migrationYear: migrationYear);
+  }
+
+  static Future<SharedPreferencesService> _createInternal(
       DateService dateService, {int? migrationYear}) async {
     SharedPreferencesService sharedPreferencesService =
         SharedPreferencesService._create(dateService);
@@ -96,12 +109,17 @@ class SharedPreferencesService {
             if (setSuccess) {
               final removeSuccess = await _sharedPreferences.remove(key);
               if (!removeSuccess) {
+                log("Failed to remove legacy key '$key' after successful migration to '$migratedKey'",
+                    level: 1000);
                 allSucceeded = false;
               }
             } else {
+              log("Failed to write migrated value for key '$migratedKey'",
+                  level: 1000);
               allSucceeded = false;
             }
-          } catch (_) {
+          } catch (e) {
+            log("Error migrating key '$key' to '$migratedKey': $e", level: 1000);
             // If decoding or merging fails, we don't remove the legacy key
             // and don't overwrite the existing yearly value with potentially
             // corrupted data.

--- a/lib/service/shared_preferences_service.dart
+++ b/lib/service/shared_preferences_service.dart
@@ -16,25 +16,25 @@ class SharedPreferencesService {
   }
 
   static Future<SharedPreferencesService> create(
-      DateService dateService) async {
+      DateService dateService, {int? migrationYear}) async {
     SharedPreferencesService sharedPreferencesService =
         SharedPreferencesService._create(dateService);
 
     sharedPreferencesService._sharedPreferences =
         await SharedPreferences.getInstance();
 
-    await sharedPreferencesService._migrateKeys();
+    await sharedPreferencesService._migrateKeys(migrationYear: migrationYear);
 
     return sharedPreferencesService;
   }
 
-  Future<void> _migrateKeys() async {
+  Future<void> _migrateKeys({int? migrationYear}) async {
     if (_sharedPreferences.getBool(migratedToYearlyKeysKey) ?? false) {
       return;
     }
 
     final keys = _sharedPreferences.getKeys();
-    final currentYear = DateTime.now().year;
+    final currentYear = migrationYear ?? DateTime.now().year;
     bool allSucceeded = true;
 
     for (String key in keys) {

--- a/lib/service/shared_preferences_service.dart
+++ b/lib/service/shared_preferences_service.dart
@@ -106,7 +106,7 @@ class SharedPreferencesService {
     int daysToTake = pill.amountOfDaysToTake;
     final pillWithTrimmedName = pill.copyWith(pillName: pill.pillName.trim());
     while (daysToTake > 0) {
-      String dateStr = _dateService.getDateAsMonthAndDay(runningDate);
+      String dateStr = _dateService.getDateAsYearMonthDay(runningDate);
       List<PillToTake> pills = getPillsToTakeForDate(dateStr);
       pills.add(pillWithTrimmedName);
       _setPillsForDate(dateStr, pills);
@@ -171,7 +171,7 @@ class SharedPreferencesService {
     DateTime runningDate = dateToRemovePillsFrom;
 
     while (now.difference(runningDate).inDays >= oneDay) {
-      String converted = _dateService.getDateAsMonthAndDay(runningDate);
+      String converted = _dateService.getDateAsYearMonthDay(runningDate);
       _setPillsForDate(converted, []);
       _setPillsTakenForDate(converted, []);
       runningDate = runningDate.add(const Duration(days: oneDay));

--- a/lib/service/shared_preferences_service.dart
+++ b/lib/service/shared_preferences_service.dart
@@ -48,7 +48,7 @@ class SharedPreferencesService {
     }
 
     final keys = _sharedPreferences.getKeys();
-    final currentYear = migrationYear ?? DateTime.now().year;
+    final currentYear = migrationYear ?? _dateService.now().year;
     bool allSucceeded = true;
 
     for (String key in keys) {
@@ -253,7 +253,7 @@ class SharedPreferencesService {
   }
 
   void clearAllPillsFromDate(DateTime dateToRemovePillsFrom) {
-    DateTime now = DateTime.now();
+    DateTime now = _dateService.now();
     DateTime runningDate = dateToRemovePillsFrom;
 
     while (now.difference(runningDate).inDays >= oneDay) {
@@ -265,7 +265,7 @@ class SharedPreferencesService {
   }
 
   void setTimeWhenApplicationWasOpened() {
-    DateTime now = DateTime.now();
+    DateTime now = _dateService.now();
     unawaited(
         _sharedPreferences.setString(timeAppOpenedKey, now.toIso8601String()));
   }
@@ -295,7 +295,7 @@ class SharedPreferencesService {
     if (timeWhenApplicationWasOpened == null) {
       setTimeWhenApplicationWasOpened();
     } else {
-      DateTime now = DateTime.now();
+      DateTime now = _dateService.now();
       if (now.difference(timeWhenApplicationWasOpened).inDays >= oneDay) {
         clearAllPillsFromDate(timeWhenApplicationWasOpened);
         setTimeWhenApplicationWasOpened();

--- a/lib/service/shared_preferences_service.dart
+++ b/lib/service/shared_preferences_service.dart
@@ -119,8 +119,9 @@ class SharedPreferencesService {
                   level: 1000);
               allSucceeded = false;
             }
-          } catch (e) {
-            log("Error migrating key '$key' to '$migratedKey': $e", level: 1000);
+          } catch (e, st) {
+            log("Error migrating key '$key' to '$migratedKey': $e",
+                level: 1000, stackTrace: st);
             // If decoding or merging fails, we don't remove the legacy key
             // and don't overwrite the existing yearly value with potentially
             // corrupted data.

--- a/lib/service/shared_preferences_service.dart
+++ b/lib/service/shared_preferences_service.dart
@@ -69,10 +69,10 @@ class SharedPreferencesService {
             final legacyPills = PillTaken.decode(legacyValue);
             final Map<int, List<PillTaken>> pillsByYear = {};
             for (final pill in legacyPills) {
-              final normalizedPill =
-                  pill.copyWith(pillName: pill.pillName.trim().toLowerCase());
-              final year = normalizedPill.lastTaken?.year ?? currentYear;
-              pillsByYear.putIfAbsent(year, () => []).add(normalizedPill);
+              final trimmedPill =
+                  pill.copyWith(pillName: pill.pillName.trim());
+              final year = trimmedPill.lastTaken?.year ?? currentYear;
+              pillsByYear.putIfAbsent(year, () => []).add(trimmedPill);
             }
 
             bool currentKeyMigrationSucceeded = true;
@@ -87,12 +87,11 @@ class SharedPreferencesService {
               if (existingYearlyValue != null) {
                 final existingPills = PillTaken.decode(existingYearlyValue);
                 // For taken pills, combine and deduplicate exact matches
-                // and normalize existing ones too
-                final normalizedExisting = existingPills
-                    .map((p) => p.copyWith(pillName: p.pillName.trim().toLowerCase()))
+                final trimmedExisting = existingPills
+                    .map((p) => p.copyWith(pillName: p.pillName.trim()))
                     .toList();
                 final merged =
-                    {...pillsForYear, ...normalizedExisting}.toList();
+                    {...pillsForYear, ...trimmedExisting}.toList();
                 migratedValue = PillTaken.encode(merged);
               } else {
                 migratedValue = PillTaken.encode(pillsForYear);
@@ -120,22 +119,22 @@ class SharedPreferencesService {
           // PillToTake key (legacy "M/D")
           final targetKey = "$currentYear/$key";
           final legacyPills = PillToTake.decode(legacyValue)
-              .map((p) => p.copyWith(pillName: p.pillName.trim().toLowerCase()))
+              .map((p) => p.copyWith(pillName: p.pillName.trim()))
               .toList();
           final existingYearlyValue = _sharedPreferences.getString(targetKey);
 
           String migratedValue;
           if (existingYearlyValue != null) {
             final existingPills = PillToTake.decode(existingYearlyValue)
-                .map((p) => p.copyWith(pillName: p.pillName.trim().toLowerCase()))
+                .map((p) => p.copyWith(pillName: p.pillName.trim()))
                 .toList();
-            // For pills to take, prefer the newer ones if names match
+            // For pills to take, prefer the newer ones if names match (case-insensitive)
             final Map<String, PillToTake> mergedMap = {};
             for (final pill in legacyPills) {
-              mergedMap[pill.pillName] = pill;
+              mergedMap[pill.pillName.toLowerCase()] = pill;
             }
             for (final pill in existingPills) {
-              mergedMap[pill.pillName] = pill;
+              mergedMap[pill.pillName.toLowerCase()] = pill;
             }
             migratedValue = PillToTake.encode(mergedMap.values.toList());
           } else {
@@ -161,7 +160,10 @@ class SharedPreferencesService {
     }
 
     if (allSucceeded) {
-      await _sharedPreferences.setBool(migratedToYearlyKeysKey, true);
+      if (!(await _sharedPreferences.setBool(migratedToYearlyKeysKey, true))) {
+        log("Failed to set migration completion flag '$migratedToYearlyKeysKey'",
+            level: 1000);
+      }
     }
   }
 
@@ -201,11 +203,11 @@ class SharedPreferencesService {
   void addPillToDates(DateTime startDate, PillToTake pill) {
     DateTime runningDate = startDate;
     int daysToTake = pill.amountOfDaysToTake;
-    final pillWithNormalizedName = pill.copyWith(pillName: pill.pillName.trim().toLowerCase());
+    final pillWithTrimmedName = pill.copyWith(pillName: pill.pillName.trim());
     while (daysToTake > 0) {
       String dateStr = _dateService.formatDateForStorage(runningDate);
       List<PillToTake> pills = getPillsToTakeForDate(dateStr);
-      pills.add(pillWithNormalizedName);
+      pills.add(pillWithTrimmedName);
       _setPillsForDate(dateStr, pills);
       runningDate = runningDate.add(const Duration(days: oneDay));
       daysToTake--;

--- a/lib/service/shared_preferences_service.dart
+++ b/lib/service/shared_preferences_service.dart
@@ -57,9 +57,42 @@ class SharedPreferencesService {
       }
 
       if (migratedKey != null) {
-        final value = _sharedPreferences.getString(key);
-        if (value != null) {
-          final setSuccess = await _sharedPreferences.setString(migratedKey, value);
+        final legacyValue = _sharedPreferences.getString(key);
+        final existingYearlyValue = _sharedPreferences.getString(migratedKey);
+
+        if (legacyValue != null) {
+          String migratedValue = legacyValue;
+
+          if (existingYearlyValue != null) {
+            try {
+              if (key.startsWith(pillsTakenKey)) {
+                final legacyMonthlyPills = PillTaken.decode(legacyValue);
+                final existingYearlyPills = PillTaken.decode(existingYearlyValue);
+                // For taken pills, combine and deduplicate exact matches
+                final merged =
+                    {...legacyMonthlyPills, ...existingYearlyPills}.toList();
+                migratedValue = PillTaken.encode(merged);
+              } else {
+                final legacyMonthlyPills = PillToTake.decode(legacyValue);
+                final existingYearlyPills = PillToTake.decode(existingYearlyValue);
+                // For pills to take, prefer the newer ones if names match
+                final Map<String, PillToTake> mergedMap = {};
+                for (final pill in legacyMonthlyPills) {
+                  mergedMap[pill.pillName.toLowerCase()] = pill;
+                }
+                for (final pill in existingYearlyPills) {
+                  mergedMap[pill.pillName.toLowerCase()] = pill;
+                }
+                migratedValue = PillToTake.encode(mergedMap.values.toList());
+              }
+            } catch (_) {
+              // On error, prefer existing (newer) value to prevent data corruption
+              migratedValue = existingYearlyValue;
+            }
+          }
+
+          final setSuccess =
+              await _sharedPreferences.setString(migratedKey, migratedValue);
           if (setSuccess) {
             final removeSuccess = await _sharedPreferences.remove(key);
             if (!removeSuccess) {

--- a/lib/service/shared_preferences_service.dart
+++ b/lib/service/shared_preferences_service.dart
@@ -23,18 +23,19 @@ class SharedPreferencesService {
     sharedPreferencesService._sharedPreferences =
         await SharedPreferences.getInstance();
 
-    sharedPreferencesService._migrateKeys();
+    await sharedPreferencesService._migrateKeys();
 
     return sharedPreferencesService;
   }
 
-  void _migrateKeys() {
+  Future<void> _migrateKeys() async {
     if (_sharedPreferences.getBool(migratedToYearlyKeysKey) ?? false) {
       return;
     }
 
     final keys = _sharedPreferences.getKeys();
     final currentYear = DateTime.now().year;
+    bool allSucceeded = true;
 
     for (String key in keys) {
       if (key == timeAppOpenedKey ||
@@ -43,29 +44,37 @@ class SharedPreferencesService {
         continue;
       }
 
+      String? migratedKey;
       // Match "M/D" or "MM/DD" but NOT "YYYY/M/D"
       // Old keys are "month/day", new keys are "year/month/day"
       if (RegExp(r'^\d{1,2}/\d{1,2}$').hasMatch(key)) {
-        final value = _sharedPreferences.getString(key);
-        if (value != null) {
-          final newKey = "$currentYear/$key";
-          unawaited(_sharedPreferences.setString(newKey, value));
-          unawaited(_sharedPreferences.remove(key));
-        }
+        migratedKey = "$currentYear/$key";
       } else if (key.startsWith(pillsTakenKey)) {
         final datePart = key.substring(pillsTakenKey.length);
         if (RegExp(r'^\d{1,2}/\d{1,2}$').hasMatch(datePart)) {
-          final value = _sharedPreferences.getString(key);
-          if (value != null) {
-            final newKey = "$pillsTakenKey$currentYear/$datePart";
-            unawaited(_sharedPreferences.setString(newKey, value));
-            unawaited(_sharedPreferences.remove(key));
+          migratedKey = "$pillsTakenKey$currentYear/$datePart";
+        }
+      }
+
+      if (migratedKey != null) {
+        final value = _sharedPreferences.getString(key);
+        if (value != null) {
+          final setSuccess = await _sharedPreferences.setString(migratedKey, value);
+          if (setSuccess) {
+            final removeSuccess = await _sharedPreferences.remove(key);
+            if (!removeSuccess) {
+              allSucceeded = false;
+            }
+          } else {
+            allSucceeded = false;
           }
         }
       }
     }
 
-    unawaited(_sharedPreferences.setBool(migratedToYearlyKeysKey, true));
+    if (allSucceeded) {
+      await _sharedPreferences.setBool(migratedToYearlyKeysKey, true);
+    }
   }
 
   // The Future returned by SharedPreferences write methods is intentionally

--- a/lib/widget/adding_pill_form.dart
+++ b/lib/widget/adding_pill_form.dart
@@ -10,9 +10,7 @@ import 'package:pill/service/date_service.dart';
 import 'package:pill/utils.dart';
 
 class AddingPillForm extends StatefulWidget {
-  final DateTime _currentDate;
-
-  const AddingPillForm(this._currentDate, {super.key});
+  const AddingPillForm({super.key});
 
   @override
   AddingPillFormState createState() {
@@ -280,11 +278,11 @@ class AddingPillFormState extends State<AddingPillForm> {
                                   amountOfDaysToTake: int.parse(
                                       _pillAmountOfDaysToTakeController.text));
 
+                              final now = DateTime.now();
                               context.read<PillBloc>().add(PillsEvent(
                                   eventName: PillEvent.addPill,
-                                  date: DateService().formatDateForStorage(
-                                      widget._currentDate),
-                                  startDateTime: widget._currentDate,
+                                  date: DateService().formatDateForStorage(now),
+                                  startDateTime: now,
                                   pillToTake: pill));
 
                               ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/widget/adding_pill_form.dart
+++ b/lib/widget/adding_pill_form.dart
@@ -7,13 +7,19 @@ import 'package:pill/custom_icons.dart';
 import 'package:pill/model/pill_duration.dart';
 import 'package:pill/model/pill_to_take.dart';
 import 'package:pill/service/date_service.dart';
+import 'package:pill/service/shared_preferences_service.dart';
 import 'package:pill/utils.dart';
 
 class AddingPillForm extends StatefulWidget {
   final DateTime pillDate;
   final DateService? dateService;
+  final SharedPreferencesService sharedPreferencesService;
 
-  const AddingPillForm({super.key, required this.pillDate, this.dateService});
+  const AddingPillForm(
+      {super.key,
+      required this.pillDate,
+      required this.sharedPreferencesService,
+      this.dateService});
 
   @override
   AddingPillFormState createState() {
@@ -106,6 +112,10 @@ class AddingPillFormState extends State<AddingPillForm> {
   @override
   Widget build(BuildContext context) {
     final dateService = widget.dateService ?? DateService();
+    final now = dateService.now();
+    final bool isStale = dateService.formatDateForStorage(widget.pillDate) !=
+        dateService.formatDateForStorage(now);
+    final effectiveDate = isStale ? now : widget.pillDate;
 
     return Container(
       padding:
@@ -116,8 +126,7 @@ class AddingPillFormState extends State<AddingPillForm> {
           mainAxisSize: MainAxisSize.min,
           children: [
             const Text(addingAPillTitle,
-                style: TextStyle(
-                    fontWeight: FontWeight.bold, fontSize: 20.0)),
+                style: TextStyle(fontWeight: FontWeight.bold, fontSize: 20.0)),
             const SizedBox(height: 25.0),
             Form(
               key: _formKey,
@@ -150,12 +159,16 @@ class AddingPillFormState extends State<AddingPillForm> {
                           return 'Please enter a pill name';
                         }
 
-                        // Duplicate prevention check
-                        final pillBloc = context.read<PillBloc>();
-                        final existingPills = pillBloc.state.pillsToTake ?? [];
+                        // Duplicate prevention check against the target date
+                        final targetDateStr =
+                            dateService.formatDateForStorage(effectiveDate);
+                        final existingPills = widget.sharedPreferencesService
+                            .getPillsToTakeForDate(targetDateStr);
+
                         final normalizedValue = value.trim().toLowerCase();
                         if (existingPills.any((p) =>
-                            p.pillName.trim().toLowerCase() == normalizedValue)) {
+                            p.pillName.trim().toLowerCase() ==
+                            normalizedValue)) {
                           return 'This pill is already in your list';
                         }
 
@@ -270,12 +283,6 @@ class AddingPillFormState extends State<AddingPillForm> {
                       ElevatedButton.icon(
                           onPressed: () {
                             if (_formKey.currentState?.validate() ?? false) {
-                              final now = dateService.now();
-                              final bool isStale = dateService.formatDateForStorage(widget.pillDate) !=
-                                  dateService.formatDateForStorage(now);
-
-                              final effectiveDate = isStale ? now : widget.pillDate;
-
                               final trimmedDescription =
                                   _pillDescriptionController.text.trim();
 
@@ -291,7 +298,8 @@ class AddingPillFormState extends State<AddingPillForm> {
 
                               context.read<PillBloc>().add(PillsEvent(
                                   eventName: PillEvent.addPill,
-                                  date: dateService.formatDateForStorage(effectiveDate),
+                                  date: dateService
+                                      .formatDateForStorage(effectiveDate),
                                   startDateTime: effectiveDate,
                                   pillToTake: pill));
 

--- a/lib/widget/adding_pill_form.dart
+++ b/lib/widget/adding_pill_form.dart
@@ -270,6 +270,12 @@ class AddingPillFormState extends State<AddingPillForm> {
                       ElevatedButton.icon(
                           onPressed: () {
                             if (_formKey.currentState?.validate() ?? false) {
+                              final now = dateService.now();
+                              final bool isStale = dateService.formatDateForStorage(widget.pillDate) !=
+                                  dateService.formatDateForStorage(now);
+
+                              final effectiveDate = isStale ? now : widget.pillDate;
+
                               final trimmedDescription =
                                   _pillDescriptionController.text.trim();
 
@@ -285,12 +291,15 @@ class AddingPillFormState extends State<AddingPillForm> {
 
                               context.read<PillBloc>().add(PillsEvent(
                                   eventName: PillEvent.addPill,
-                                  date: dateService.formatDateForStorage(widget.pillDate),
-                                  startDateTime: widget.pillDate,
+                                  date: dateService.formatDateForStorage(effectiveDate),
+                                  startDateTime: effectiveDate,
                                   pillToTake: pill));
 
                               ScaffoldMessenger.of(context).showSnackBar(
-                                const SnackBar(content: Text("Pill Added!")),
+                                SnackBar(
+                                    content: Text(isStale
+                                        ? "Day changed! Pill added for today."
+                                        : "Pill Added!")),
                               );
 
                               FocusScope.of(context).unfocus();

--- a/lib/widget/adding_pill_form.dart
+++ b/lib/widget/adding_pill_form.dart
@@ -282,7 +282,7 @@ class AddingPillFormState extends State<AddingPillForm> {
 
                               context.read<PillBloc>().add(PillsEvent(
                                   eventName: PillEvent.addPill,
-                                  date: DateService().getDateAsYearMonthDay(
+                                  date: DateService().formatDateForStorage(
                                       widget._currentDate),
                                   startDateTime: widget._currentDate,
                                   pillToTake: pill));

--- a/lib/widget/adding_pill_form.dart
+++ b/lib/widget/adding_pill_form.dart
@@ -10,7 +10,9 @@ import 'package:pill/service/date_service.dart';
 import 'package:pill/utils.dart';
 
 class AddingPillForm extends StatefulWidget {
-  const AddingPillForm({super.key});
+  final DateTime pillDate;
+
+  const AddingPillForm({super.key, required this.pillDate});
 
   @override
   AddingPillFormState createState() {
@@ -278,11 +280,10 @@ class AddingPillFormState extends State<AddingPillForm> {
                                   amountOfDaysToTake: int.parse(
                                       _pillAmountOfDaysToTakeController.text));
 
-                              final now = DateTime.now();
                               context.read<PillBloc>().add(PillsEvent(
                                   eventName: PillEvent.addPill,
-                                  date: DateService().formatDateForStorage(now),
-                                  startDateTime: now,
+                                  date: DateService().formatDateForStorage(widget.pillDate),
+                                  startDateTime: widget.pillDate,
                                   pillToTake: pill));
 
                               ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/widget/adding_pill_form.dart
+++ b/lib/widget/adding_pill_form.dart
@@ -11,8 +11,9 @@ import 'package:pill/utils.dart';
 
 class AddingPillForm extends StatefulWidget {
   final DateTime pillDate;
+  final DateService? dateService;
 
-  const AddingPillForm({super.key, required this.pillDate});
+  const AddingPillForm({super.key, required this.pillDate, this.dateService});
 
   @override
   AddingPillFormState createState() {
@@ -104,6 +105,8 @@ class AddingPillFormState extends State<AddingPillForm> {
 
   @override
   Widget build(BuildContext context) {
+    final dateService = widget.dateService ?? DateService();
+
     return Container(
       padding:
           EdgeInsets.only(bottom: MediaQuery.of(context).viewInsets.bottom),
@@ -282,7 +285,7 @@ class AddingPillFormState extends State<AddingPillForm> {
 
                               context.read<PillBloc>().add(PillsEvent(
                                   eventName: PillEvent.addPill,
-                                  date: DateService().formatDateForStorage(widget.pillDate),
+                                  date: dateService.formatDateForStorage(widget.pillDate),
                                   startDateTime: widget.pillDate,
                                   pillToTake: pill));
 

--- a/lib/widget/adding_pill_form.dart
+++ b/lib/widget/adding_pill_form.dart
@@ -282,7 +282,7 @@ class AddingPillFormState extends State<AddingPillForm> {
 
                               context.read<PillBloc>().add(PillsEvent(
                                   eventName: PillEvent.addPill,
-                                  date: DateService().getDateAsMonthAndDay(
+                                  date: DateService().getDateAsYearMonthDay(
                                       widget._currentDate),
                                   startDateTime: widget._currentDate,
                                   pillToTake: pill));

--- a/lib/widget/day_widget.dart
+++ b/lib/widget/day_widget.dart
@@ -48,7 +48,7 @@ class DayWidget extends StatelessWidget {
                     onDismissed: (direction) {
                       context.read<PillBloc>().add(PillsEvent(
                           eventName: PillEvent.removePill,
-                          date: dateService.getDateAsMonthAndDay(date),
+                          date: dateService.getDateAsYearMonthDay(date),
                           pillToTake: pillsToTake[index]));
                     })),
           );
@@ -86,7 +86,7 @@ class DayWidget extends StatelessWidget {
             alignment: Alignment.topCenter,
             child: Padding(
               padding: const EdgeInsets.only(top: 40.0),
-              child: Text(dateService.getDateAsMonthAndDay(date),
+              child: Text(dateService.getDateAsYearMonthDay(date),
                   style: const TextStyle(
                       fontSize: 25.0, fontWeight: FontWeight.bold)),
             ),

--- a/lib/widget/day_widget.dart
+++ b/lib/widget/day_widget.dart
@@ -47,9 +47,22 @@ class DayWidget extends StatelessWidget {
                       date: date,
                     ),
                     onDismissed: (direction) {
+                      final now = DateTime.now();
+                      final todayStr = dateService.formatDateForStorage(now);
+                      final widgetDateStr =
+                          dateService.formatDateForStorage(date);
+
+                      if (todayStr != widgetDateStr) {
+                        // Day has rolled over. Refresh the UI instead of
+                        // removing from a stale record.
+                        context.read<PillBloc>().add(PillsEvent(
+                            eventName: PillEvent.loadPills, date: todayStr));
+                        return;
+                      }
+
                       context.read<PillBloc>().add(PillsEvent(
                           eventName: PillEvent.removePill,
-                          date: dateService.formatDateForStorage(date),
+                          date: widgetDateStr,
                           pillToTake: pillsToTake[index]));
                     })),
           );

--- a/lib/widget/day_widget.dart
+++ b/lib/widget/day_widget.dart
@@ -41,12 +41,7 @@ class DayWidget extends StatelessWidget {
                 itemCount: pillsToTake.length,
                 itemBuilder: (_, index) => Dismissible(
                     key: ObjectKey(pillsToTake[index].pillName),
-                    child: PillWidget(
-                      pillToTake: pillsToTake[index],
-                      dateService: dateService,
-                      date: date,
-                    ),
-                    onDismissed: (direction) {
+                    confirmDismiss: (direction) async {
                       final now = dateService.now();
                       final todayStr = dateService.formatDateForStorage(now);
                       final widgetDateStr =
@@ -57,14 +52,24 @@ class DayWidget extends StatelessWidget {
                         // removing from a stale record.
                         context.read<PillBloc>().add(PillsEvent(
                             eventName: PillEvent.loadPills, date: todayStr));
-                        return;
+                        return false;
                       }
+                      return true;
+                    },
+                    onDismissed: (direction) {
+                      final widgetDateStr =
+                          dateService.formatDateForStorage(date);
 
                       context.read<PillBloc>().add(PillsEvent(
                           eventName: PillEvent.removePill,
                           date: widgetDateStr,
                           pillToTake: pillsToTake[index]));
-                    })),
+                    },
+                    child: PillWidget(
+                      pillToTake: pillsToTake[index],
+                      dateService: dateService,
+                      date: date,
+                    ))),
           );
   }
 

--- a/lib/widget/day_widget.dart
+++ b/lib/widget/day_widget.dart
@@ -47,7 +47,7 @@ class DayWidget extends StatelessWidget {
                       date: date,
                     ),
                     onDismissed: (direction) {
-                      final now = DateTime.now();
+                      final now = dateService.now();
                       final todayStr = dateService.formatDateForStorage(now);
                       final widgetDateStr =
                           dateService.formatDateForStorage(date);

--- a/lib/widget/day_widget.dart
+++ b/lib/widget/day_widget.dart
@@ -44,6 +44,7 @@ class DayWidget extends StatelessWidget {
                     child: PillWidget(
                       pillToTake: pillsToTake[index],
                       dateService: dateService,
+                      date: date,
                     ),
                     onDismissed: (direction) {
                       context.read<PillBloc>().add(PillsEvent(

--- a/lib/widget/day_widget.dart
+++ b/lib/widget/day_widget.dart
@@ -48,7 +48,7 @@ class DayWidget extends StatelessWidget {
                     onDismissed: (direction) {
                       context.read<PillBloc>().add(PillsEvent(
                           eventName: PillEvent.removePill,
-                          date: dateService.getDateAsYearMonthDay(date),
+                          date: dateService.formatDateForStorage(date),
                           pillToTake: pillsToTake[index]));
                     })),
           );
@@ -86,7 +86,7 @@ class DayWidget extends StatelessWidget {
             alignment: Alignment.topCenter,
             child: Padding(
               padding: const EdgeInsets.only(top: 40.0),
-              child: Text(dateService.getDateAsYearMonthDay(date),
+              child: Text(dateService.formatDateForDisplay(date),
                   style: const TextStyle(
                       fontSize: 25.0, fontWeight: FontWeight.bold)),
             ),

--- a/lib/widget/day_widget.dart
+++ b/lib/widget/day_widget.dart
@@ -49,7 +49,7 @@ class DayWidget extends StatelessWidget {
                     onDismissed: (direction) {
                       context.read<PillBloc>().add(PillsEvent(
                           eventName: PillEvent.removePill,
-                          date: dateService.formatDateForStorage(DateTime.now()),
+                          date: dateService.formatDateForStorage(date),
                           pillToTake: pillsToTake[index]));
                     })),
           );

--- a/lib/widget/day_widget.dart
+++ b/lib/widget/day_widget.dart
@@ -49,7 +49,7 @@ class DayWidget extends StatelessWidget {
                     onDismissed: (direction) {
                       context.read<PillBloc>().add(PillsEvent(
                           eventName: PillEvent.removePill,
-                          date: dateService.formatDateForStorage(date),
+                          date: dateService.formatDateForStorage(DateTime.now()),
                           pillToTake: pillsToTake[index]));
                     })),
           );

--- a/lib/widget/pill_to_take_widget.dart
+++ b/lib/widget/pill_to_take_widget.dart
@@ -23,7 +23,7 @@ class PillWidget extends StatelessWidget {
           pillRegiment: pillToTake.pillRegiment - 1, lastTaken: now);
       context.read<PillBloc>().add(PillsEvent(
           eventName: PillEvent.updatePill,
-          date: dateService.formatDateForStorage(date),
+          date: dateService.formatDateForStorage(now),
           pillToTake: updatedPillToTake));
     }
   }

--- a/lib/widget/pill_to_take_widget.dart
+++ b/lib/widget/pill_to_take_widget.dart
@@ -7,10 +7,14 @@ import 'package:pill/service/date_service.dart';
 
 class PillWidget extends StatelessWidget {
   const PillWidget(
-      {super.key, required this.pillToTake, required this.dateService});
+      {super.key,
+      required this.pillToTake,
+      required this.dateService,
+      required this.date});
 
   final PillToTake pillToTake;
   final DateService dateService;
+  final DateTime date;
 
   void _handleOnTap(BuildContext context) {
     if (pillToTake.pillRegiment > 0) {
@@ -19,7 +23,7 @@ class PillWidget extends StatelessWidget {
           pillRegiment: pillToTake.pillRegiment - 1, lastTaken: now);
       context.read<PillBloc>().add(PillsEvent(
           eventName: PillEvent.updatePill,
-          date: dateService.formatDateForStorage(now),
+          date: dateService.formatDateForStorage(date),
           pillToTake: updatedPillToTake));
     }
   }

--- a/lib/widget/pill_to_take_widget.dart
+++ b/lib/widget/pill_to_take_widget.dart
@@ -17,7 +17,7 @@ class PillWidget extends StatelessWidget {
   final DateTime date;
 
   void _handleOnTap(BuildContext context) {
-    final now = DateTime.now();
+    final now = dateService.now();
     final todayStr = dateService.formatDateForStorage(now);
     final widgetDateStr = dateService.formatDateForStorage(date);
 

--- a/lib/widget/pill_to_take_widget.dart
+++ b/lib/widget/pill_to_take_widget.dart
@@ -17,13 +17,25 @@ class PillWidget extends StatelessWidget {
   final DateTime date;
 
   void _handleOnTap(BuildContext context) {
+    final now = DateTime.now();
+    final todayStr = dateService.formatDateForStorage(now);
+    final widgetDateStr = dateService.formatDateForStorage(date);
+
+    if (todayStr != widgetDateStr) {
+      // Day has rolled over. Refresh the UI to show today's pills instead
+      // of updating a stale record with a "now" timestamp.
+      context.read<PillBloc>().add(PillsEvent(
+          eventName: PillEvent.loadPills,
+          date: todayStr));
+      return;
+    }
+
     if (pillToTake.pillRegiment > 0) {
-      final now = DateTime.now();
       PillToTake updatedPillToTake = pillToTake.copyWith(
           pillRegiment: pillToTake.pillRegiment - 1, lastTaken: now);
       context.read<PillBloc>().add(PillsEvent(
           eventName: PillEvent.updatePill,
-          date: dateService.formatDateForStorage(date),
+          date: widgetDateStr,
           pillToTake: updatedPillToTake));
     }
   }

--- a/lib/widget/pill_to_take_widget.dart
+++ b/lib/widget/pill_to_take_widget.dart
@@ -18,7 +18,7 @@ class PillWidget extends StatelessWidget {
           pillRegiment: pillToTake.pillRegiment - 1, lastTaken: DateTime.now());
       context.read<PillBloc>().add(PillsEvent(
           eventName: PillEvent.updatePill,
-          date: dateService.getCurrentDateAsMonthAndDay(),
+          date: dateService.getCurrentDateAsYearMonthDay(),
           pillToTake: updatedPillToTake));
     }
   }

--- a/lib/widget/pill_to_take_widget.dart
+++ b/lib/widget/pill_to_take_widget.dart
@@ -18,7 +18,7 @@ class PillWidget extends StatelessWidget {
           pillRegiment: pillToTake.pillRegiment - 1, lastTaken: DateTime.now());
       context.read<PillBloc>().add(PillsEvent(
           eventName: PillEvent.updatePill,
-          date: dateService.getCurrentDateAsYearMonthDay(),
+          date: dateService.formatDateForStorage(DateTime.now()),
           pillToTake: updatedPillToTake));
     }
   }

--- a/lib/widget/pill_to_take_widget.dart
+++ b/lib/widget/pill_to_take_widget.dart
@@ -23,7 +23,7 @@ class PillWidget extends StatelessWidget {
           pillRegiment: pillToTake.pillRegiment - 1, lastTaken: now);
       context.read<PillBloc>().add(PillsEvent(
           eventName: PillEvent.updatePill,
-          date: dateService.formatDateForStorage(now),
+          date: dateService.formatDateForStorage(date),
           pillToTake: updatedPillToTake));
     }
   }

--- a/lib/widget/pill_to_take_widget.dart
+++ b/lib/widget/pill_to_take_widget.dart
@@ -14,11 +14,12 @@ class PillWidget extends StatelessWidget {
 
   void _handleOnTap(BuildContext context) {
     if (pillToTake.pillRegiment > 0) {
+      final now = DateTime.now();
       PillToTake updatedPillToTake = pillToTake.copyWith(
-          pillRegiment: pillToTake.pillRegiment - 1, lastTaken: DateTime.now());
+          pillRegiment: pillToTake.pillRegiment - 1, lastTaken: now);
       context.read<PillBloc>().add(PillsEvent(
           eventName: PillEvent.updatePill,
-          date: dateService.formatDateForStorage(DateTime.now()),
+          date: dateService.formatDateForStorage(now),
           pillToTake: updatedPillToTake));
     }
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -233,7 +233,7 @@ packages:
     source: hosted
     version: "0.11.1"
   meta:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: meta
       sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,6 +32,7 @@ dependencies:
   flutter_launcher_icons: ^0.14.3
   flutter_bloc: ^9.1.0
   equatable: ^2.0.7
+  meta: ^1.11.0
 
 dev_dependencies:
   flutter_test:

--- a/test/adding_pill_form_test.dart
+++ b/test/adding_pill_form_test.dart
@@ -7,26 +7,39 @@ import 'package:pill/service/shared_preferences_service.dart';
 import 'package:pill/widget/adding_pill_form.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-void main() async {
+void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
-  DateService dateService = DateService();
-  SharedPreferences.setMockInitialValues({});
-  SharedPreferencesService sharedPreferencesService =
-      await SharedPreferencesService.create(dateService);
-  
-  Widget base = MultiBlocProvider(providers: [
-    BlocProvider(create: (context) => PillBloc(sharedPreferencesService)),
-  ], child: const MaterialApp(home: Scaffold(body: AddingPillForm())));
+  late DateService dateService;
+  late SharedPreferencesService sharedPreferencesService;
+  final testDate = DateTime(2023, 1, 1);
+
+  setUp(() async {
+    dateService = DateService();
+    SharedPreferences.setMockInitialValues({});
+    sharedPreferencesService = await SharedPreferencesService.create(dateService);
+  });
+
+  Widget getBase() => MultiBlocProvider(
+        providers: [
+          BlocProvider(create: (context) => PillBloc(sharedPreferencesService)),
+        ],
+        child: MaterialApp(
+          home: Scaffold(
+            body: AddingPillForm(pillDate: testDate),
+          ),
+        ),
+      );
 
   testWidgets("Adding Pill Form - Add A Pill with Defaults", (WidgetTester tester) async {
-    await tester.pumpWidget(base);
-
-    await tester.ensureVisible(find.byType(AddingPillForm));
+    await tester.pumpWidget(getBase());
+    await tester.pumpAndSettle();
 
     await tester.enterText(find.byKey(const ValueKey("pillName")), "Test Pill");
-    // Regiment and Days already have defaults (1 and 7)
-
-    await tester.tap(find.byIcon(Icons.check));
+    
+    // We need to ensure the button is visible before tapping
+    final applyButton = find.text("Apply");
+    await tester.ensureVisible(applyButton);
+    await tester.tap(applyButton);
 
     await tester.pumpAndSettle();
 
@@ -34,16 +47,15 @@ void main() async {
     expect(find.byType(AddingPillForm), findsNothing);
   });
 
-  testWidgets("Adding Pill Form - Trying to add a pill with an empty name",
-      (WidgetTester tester) async {
-    await tester.pumpWidget(base);
+  testWidgets("Adding Pill Form - Trying to add a pill with an empty name", (WidgetTester tester) async {
+    await tester.pumpWidget(getBase());
+    await tester.pumpAndSettle();
 
-    await tester.ensureVisible(find.byType(AddingPillForm));
-    
-    // Clear the name field (it's empty by default anyway)
     await tester.enterText(find.byKey(const ValueKey("pillName")), "");
 
-    await tester.tap(find.byIcon(Icons.check));
+    final applyButton = find.text("Apply");
+    await tester.ensureVisible(applyButton);
+    await tester.tap(applyButton);
 
     await tester.pumpAndSettle();
 
@@ -51,38 +63,41 @@ void main() async {
   });
 
   testWidgets("Adding Pill Form - Add Pill with Instructions", (WidgetTester tester) async {
-    await tester.pumpWidget(base);
-
-    await tester.ensureVisible(find.byType(AddingPillForm));
+    await tester.pumpWidget(getBase());
+    await tester.pumpAndSettle();
 
     await tester.enterText(find.byKey(const ValueKey("pillName")), "Test Pill");
-    await tester.enterText(find.byKey(const ValueKey("pillDescription")), "Take after eating");
+    
+    final descField = find.byKey(const ValueKey("pillDescription"));
+    await tester.ensureVisible(descField);
+    await tester.enterText(descField, "Take after eating");
 
-    await tester.tap(find.byIcon(Icons.check));
+    final applyButton = find.text("Apply");
+    await tester.ensureVisible(applyButton);
+    await tester.tap(applyButton);
 
     await tester.pumpAndSettle();
 
     expect(find.byType(AddingPillForm), findsNothing);
   });
 
-  testWidgets("Adding Pill Form - Try to add pill with numbers as pill name",
-      (WidgetTester tester) async {
-    await tester.pumpWidget(base);
+  testWidgets("Adding Pill Form - Try to add pill with numbers as pill name", (WidgetTester tester) async {
+    await tester.pumpWidget(getBase());
+    await tester.pumpAndSettle();
 
-    await tester.ensureVisible(find.byType(AddingPillForm));
+    final pillNameField = find.byKey(const ValueKey("pillName"));
+    // Input formatter should block numbers, resulting in an empty field
+    await tester.enterText(pillNameField, "1234");
 
-    // Input formatter should block numbers
-    await tester.enterText(find.byKey(const ValueKey("pillName")), "1234");
-
-    await tester.tap(find.byIcon(Icons.check));
+    final applyButton = find.text("Apply");
+    await tester.ensureVisible(applyButton);
+    await tester.tap(applyButton);
 
     await tester.pumpAndSettle();
 
     expect(find.text("Please enter a pill name"), findsOneWidget);
 
-    TextFormField pillName =
-        tester.widget<TextFormField>(find.byKey(const ValueKey("pillName")));
-
-    expect(pillName.controller?.text.length, 0);
+    final pillNameWidget = tester.widget<TextFormField>(pillNameField);
+    expect(pillNameWidget.controller?.text.length, 0);
   });
 }

--- a/test/adding_pill_form_test.dart
+++ b/test/adding_pill_form_test.dart
@@ -16,7 +16,7 @@ void main() async {
   
   Widget base = MultiBlocProvider(providers: [
     BlocProvider(create: (context) => PillBloc(sharedPreferencesService)),
-  ], child: MaterialApp(home: Scaffold(body: AddingPillForm(DateTime.now()))));
+  ], child: const MaterialApp(home: Scaffold(body: AddingPillForm())));
 
   testWidgets("Adding Pill Form - Add A Pill with Defaults", (WidgetTester tester) async {
     await tester.pumpWidget(base);

--- a/test/adding_pill_form_test.dart
+++ b/test/adding_pill_form_test.dart
@@ -25,7 +25,9 @@ void main() {
         ],
         child: MaterialApp(
           home: Scaffold(
-            body: AddingPillForm(pillDate: testDate),
+            body: AddingPillForm(
+                pillDate: testDate,
+                sharedPreferencesService: sharedPreferencesService),
           ),
         ),
       );

--- a/test/adding_pill_form_test.dart
+++ b/test/adding_pill_form_test.dart
@@ -21,7 +21,7 @@ void main() {
 
   Widget getBase() => MultiBlocProvider(
         providers: [
-          BlocProvider(create: (context) => PillBloc(sharedPreferencesService)),
+          BlocProvider(create: (context) => PillBloc(sharedPreferencesService, dateService)),
         ],
         child: MaterialApp(
           home: Scaffold(

--- a/test/date_service_test.dart
+++ b/test/date_service_test.dart
@@ -4,10 +4,16 @@ import 'package:pill/service/date_service.dart';
 void main() {
   DateService dateService = DateService();
 
-  test("DateService convert date to year, month and day", () {
+  test("DateService formatDateForStorage returns YYYY/M/D", () {
     final DateTime date = DateTime.parse("2022-05-06");
-    final String str = dateService.getDateAsYearMonthDay(date);
+    final String str = dateService.formatDateForStorage(date);
     expect(str, equals("2022/5/6"));
+  });
+
+  test("DateService formatDateForDisplay returns M/D", () {
+    final DateTime date = DateTime.parse("2022-05-06");
+    final String str = dateService.formatDateForDisplay(date);
+    expect(str, equals("5/6"));
   });
 
   test("DateService get hour from date", () {

--- a/test/date_service_test.dart
+++ b/test/date_service_test.dart
@@ -6,7 +6,7 @@ void main() {
 
   test("DateService convert date to year, month and day", () {
     final DateTime date = DateTime.parse("2022-05-06");
-    final String str = dateService.getDateAsMonthAndDay(date);
+    final String str = dateService.getDateAsYearMonthDay(date);
     expect(str, equals("2022/5/6"));
   });
 

--- a/test/date_service_test.dart
+++ b/test/date_service_test.dart
@@ -4,10 +4,10 @@ import 'package:pill/service/date_service.dart';
 void main() {
   DateService dateService = DateService();
 
-  test("DateService convert date to month and day", () {
+  test("DateService convert date to year, month and day", () {
     final DateTime date = DateTime.parse("2022-05-06");
     final String str = dateService.getDateAsMonthAndDay(date);
-    expect(str, equals("5/6"));
+    expect(str, equals("2022/5/6"));
   });
 
   test("DateService get hour from date", () {

--- a/test/day_widget_rollover_test.dart
+++ b/test/day_widget_rollover_test.dart
@@ -57,6 +57,9 @@ void main() {
         initialState: PillState(pillsToTake: const [testPill]));
   });
 
+  tearDown(() async {
+    await mockPillBloc.close();
+  });
   Widget getBase() => BlocProvider<PillBloc>.value(
         value: mockPillBloc,
         child: MaterialApp(

--- a/test/day_widget_rollover_test.dart
+++ b/test/day_widget_rollover_test.dart
@@ -1,0 +1,127 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pill/bloc/pill/pill_bloc.dart';
+import 'package:pill/bloc/pill/pill_state.dart';
+import 'package:pill/model/pill_to_take.dart';
+import 'package:pill/service/date_service.dart';
+import 'package:pill/service/shared_preferences_service.dart';
+import 'package:pill/widget/day_widget.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class MockDateService extends DateService {
+  DateTime _now;
+  MockDateService(this._now);
+
+  @override
+  DateTime now() => _now;
+
+  void setNow(DateTime newNow) {
+    _now = newNow;
+  }
+}
+
+class MockPillBloc extends PillBloc {
+  final List<PillsEvent> capturedEvents = [];
+
+  MockPillBloc(super.sharedPreferencesService, super.dateService, {PillState? initialState})
+      : _initialState = initialState ?? PillState();
+
+  final PillState _initialState;
+
+  @override
+  PillState get state => _initialState;
+
+  @override
+  void add(PillsEvent event) {
+    capturedEvents.add(event);
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  late MockDateService dateService;
+  late MockPillBloc mockPillBloc;
+  late SharedPreferencesService sharedPreferencesService;
+  final DateTime widgetDate = DateTime(2023, 1, 1);
+  const testPill = PillToTake(
+      pillName: "Test Pill",
+      pillRegiment: 1,
+      amountOfDaysToTake: 1);
+
+  setUp(() async {
+    dateService = MockDateService(widgetDate);
+    SharedPreferences.setMockInitialValues({});
+    sharedPreferencesService = await SharedPreferencesService.create(dateService);
+    mockPillBloc = MockPillBloc(sharedPreferencesService, dateService, 
+        initialState: PillState(pillsToTake: const [testPill]));
+  });
+
+  Widget getBase() => BlocProvider<PillBloc>.value(
+        value: mockPillBloc,
+        child: MaterialApp(
+          home: Scaffold(
+            body: Column(
+              children: [
+                DayWidget(
+                  date: widgetDate,
+                  mode: DayWidgetMode.toTake,
+                  dateService: dateService,
+                ),
+              ],
+            ),
+          ),
+        ),
+      );
+
+  testWidgets("DayWidget - Rollover in onDismissed: Tapping on a stale day triggers loadPills",
+      (WidgetTester tester) async {
+    // 1. Setup: Current time is a different day (rollover)
+    final tomorrow = widgetDate.add(const Duration(days: 1));
+    dateService.setNow(tomorrow);
+
+    await tester.pumpWidget(getBase());
+    await tester.pumpAndSettle();
+
+    // 2. Action: Dismiss the pill (swipe left)
+    await tester.drag(find.byType(Dismissible), const Offset(-500.0, 0.0));
+    await tester.pumpAndSettle();
+
+    // 3. Assertion: Verify loadPills was dispatched, NOT removePill
+    final loadPillsEvents = mockPillBloc.capturedEvents
+        .where((e) => e.eventName == PillEvent.loadPills)
+        .toList();
+    final removePillEvents = mockPillBloc.capturedEvents
+        .where((e) => e.eventName == PillEvent.removePill)
+        .toList();
+
+    expect(loadPillsEvents.length, 1);
+    expect(loadPillsEvents.first.date, dateService.formatDateForStorage(tomorrow));
+    expect(removePillEvents.isEmpty, true);
+  });
+
+  testWidgets("DayWidget - No Rollover in onDismissed: Tapping on current day triggers removePill",
+      (WidgetTester tester) async {
+    // 1. Setup: Current time is the same day
+    dateService.setNow(widgetDate);
+
+    await tester.pumpWidget(getBase());
+    await tester.pumpAndSettle();
+
+    // 2. Action: Dismiss the pill (swipe left)
+    await tester.drag(find.byType(Dismissible), const Offset(-500.0, 0.0));
+    await tester.pumpAndSettle();
+
+    // 3. Assertion: Verify removePill was dispatched
+    final loadPillsEvents = mockPillBloc.capturedEvents
+        .where((e) => e.eventName == PillEvent.loadPills)
+        .toList();
+    final removePillEvents = mockPillBloc.capturedEvents
+        .where((e) => e.eventName == PillEvent.removePill)
+        .toList();
+
+    expect(removePillEvents.length, 1);
+    expect(removePillEvents.first.date, dateService.formatDateForStorage(widgetDate));
+    expect(loadPillsEvents.isEmpty, true);
+  });
+}

--- a/test/day_widget_test.dart
+++ b/test/day_widget_test.dart
@@ -91,7 +91,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.byType(PillWidget), findsOneWidget);
-    expect(find.text("test pill"), findsOneWidget);
+    expect(find.text("Test Pill"), findsOneWidget);
     expect(find.text(pillsToTakeHeader), findsNothing);
   });
 
@@ -117,7 +117,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.byType(PillTakenWidget), findsOneWidget);
-    expect(find.text("taken pill"), findsOneWidget);
+    expect(find.text("Taken Pill"), findsOneWidget);
     expect(find.text(pillsTakenHeader), findsNothing);
   });
 

--- a/test/day_widget_test.dart
+++ b/test/day_widget_test.dart
@@ -91,7 +91,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.byType(PillWidget), findsOneWidget);
-    expect(find.text("Test Pill"), findsOneWidget);
+    expect(find.text("test pill"), findsOneWidget);
     expect(find.text(pillsToTakeHeader), findsNothing);
   });
 
@@ -117,7 +117,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.byType(PillTakenWidget), findsOneWidget);
-    expect(find.text("Taken Pill"), findsOneWidget);
+    expect(find.text("taken pill"), findsOneWidget);
     expect(find.text(pillsTakenHeader), findsNothing);
   });
 

--- a/test/day_widget_test.dart
+++ b/test/day_widget_test.dart
@@ -19,7 +19,7 @@ void main() {
   final dateService = DateService();
 
   final testDate = DateTime(2023, 10, 10);
-  final testDateStr = dateService.getDateAsMonthAndDay(testDate);
+  final testDateStr = dateService.getDateAsYearMonthDay(testDate);
 
   setUp(() async {
     SharedPreferences.setMockInitialValues({});

--- a/test/day_widget_test.dart
+++ b/test/day_widget_test.dart
@@ -19,7 +19,8 @@ void main() {
   final dateService = DateService();
 
   final testDate = DateTime(2023, 10, 10);
-  final testDateStr = dateService.getDateAsYearMonthDay(testDate);
+  final testDateStorageStr = dateService.formatDateForStorage(testDate);
+  final testDateDisplayStr = dateService.formatDateForDisplay(testDate);
 
   setUp(() async {
     SharedPreferences.setMockInitialValues({});
@@ -41,7 +42,7 @@ void main() {
     await tester.runAsync(() async {
       pillBloc.add(PillsEvent(
         eventName: PillEvent.loadPills,
-        date: testDateStr,
+        date: testDateStorageStr,
       ));
       // Wait for the bloc to emit the new state from the loadPills event
       await pillBloc.stream.first;
@@ -74,7 +75,7 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(find.text(pillsToTakeHeader), findsOneWidget);
-    expect(find.text(testDateStr), findsOneWidget);
+    expect(find.text(testDateDisplayStr), findsOneWidget);
 
     // 2. Write to service synchronously, then drive bloc state update via
     //    tester.runAsync so the stream emission fully completes
@@ -109,7 +110,7 @@ void main() {
     await seedBlocState(tester, () {
       sharedPreferencesService.addPillToDates(testDate, pill);
       sharedPreferencesService.updatePillForDate(
-          pill.copyWith(pillRegiment: 0, lastTaken: testDate), testDateStr);
+          pill.copyWith(pillRegiment: 0, lastTaken: testDate), testDateStorageStr);
     });
 
     await tester.pump();

--- a/test/day_widget_test.dart
+++ b/test/day_widget_test.dart
@@ -26,7 +26,7 @@ void main() {
     SharedPreferences.setMockInitialValues({});
     sharedPreferencesService =
         await SharedPreferencesService.create(dateService);
-    pillBloc = PillBloc(sharedPreferencesService);
+    pillBloc = PillBloc(sharedPreferencesService, dateService);
   });
 
   tearDown(() async {

--- a/test/pill_widget_rollover_test.dart
+++ b/test/pill_widget_rollover_test.dart
@@ -45,6 +45,9 @@ void main() {
     mockPillBloc = MockPillBloc(sharedPreferencesService, dateService);
   });
 
+  tearDown(() async {
+    await mockPillBloc.close();
+  });
   Widget getBase() => BlocProvider<PillBloc>.value(
         value: mockPillBloc,
         child: MaterialApp(

--- a/test/pill_widget_rollover_test.dart
+++ b/test/pill_widget_rollover_test.dart
@@ -1,0 +1,114 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pill/bloc/pill/pill_bloc.dart';
+import 'package:pill/model/pill_to_take.dart';
+import 'package:pill/service/date_service.dart';
+import 'package:pill/service/shared_preferences_service.dart';
+import 'package:pill/widget/pill_to_take_widget.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class MockDateService extends DateService {
+  DateTime _now;
+  MockDateService(this._now);
+
+  @override
+  DateTime now() => _now;
+
+  void setNow(DateTime newNow) {
+    _now = newNow;
+  }
+}
+
+class MockPillBloc extends PillBloc {
+  final List<PillsEvent> capturedEvents = [];
+
+  MockPillBloc(super.sharedPreferencesService, super.dateService);
+
+  @override
+  void add(PillsEvent event) {
+    capturedEvents.add(event);
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  late MockDateService dateService;
+  late MockPillBloc mockPillBloc;
+  late SharedPreferencesService sharedPreferencesService;
+  final DateTime widgetDate = DateTime(2023, 1, 1);
+
+  setUp(() async {
+    dateService = MockDateService(widgetDate);
+    SharedPreferences.setMockInitialValues({});
+    sharedPreferencesService = await SharedPreferencesService.create(dateService);
+    mockPillBloc = MockPillBloc(sharedPreferencesService, dateService);
+  });
+
+  Widget getBase() => BlocProvider<PillBloc>.value(
+        value: mockPillBloc,
+        child: MaterialApp(
+          home: Scaffold(
+            body: PillWidget(
+              pillToTake: const PillToTake(
+                  pillName: "Test Pill",
+                  pillRegiment: 1,
+                  amountOfDaysToTake: 1),
+              dateService: dateService,
+              date: widgetDate,
+            ),
+          ),
+        ),
+      );
+
+  testWidgets("PillWidget - Rollover: Tapping on a stale day triggers loadPills",
+      (WidgetTester tester) async {
+    // 1. Setup: Current time is a different day (rollover)
+    final tomorrow = widgetDate.add(const Duration(days: 1));
+    dateService.setNow(tomorrow);
+
+    await tester.pumpWidget(getBase());
+    await tester.pumpAndSettle();
+
+    // 2. Action: Tap the pill widget
+    await tester.tap(find.byType(PillWidget));
+    await tester.pumpAndSettle();
+
+    // 3. Assertion: Verify loadPills was dispatched, NOT updatePill
+    final loadPillsEvents = mockPillBloc.capturedEvents
+        .where((e) => e.eventName == PillEvent.loadPills)
+        .toList();
+    final updatePillEvents = mockPillBloc.capturedEvents
+        .where((e) => e.eventName == PillEvent.updatePill)
+        .toList();
+
+    expect(loadPillsEvents.length, 1);
+    expect(loadPillsEvents.first.date, dateService.formatDateForStorage(tomorrow));
+    expect(updatePillEvents.isEmpty, true);
+  });
+
+  testWidgets("PillWidget - No Rollover: Tapping on current day triggers updatePill",
+      (WidgetTester tester) async {
+    // 1. Setup: Current time is the same day
+    dateService.setNow(widgetDate);
+
+    await tester.pumpWidget(getBase());
+    await tester.pumpAndSettle();
+
+    // 2. Action: Tap the pill widget
+    await tester.tap(find.byType(PillWidget));
+    await tester.pumpAndSettle();
+
+    // 3. Assertion: Verify updatePill was dispatched
+    final loadPillsEvents = mockPillBloc.capturedEvents
+        .where((e) => e.eventName == PillEvent.loadPills)
+        .toList();
+    final updatePillEvents = mockPillBloc.capturedEvents
+        .where((e) => e.eventName == PillEvent.updatePill)
+        .toList();
+
+    expect(updatePillEvents.length, 1);
+    expect(updatePillEvents.first.date, dateService.formatDateForStorage(widgetDate));
+    expect(loadPillsEvents.isEmpty, true);
+  });
+}

--- a/test/pill_widget_test.dart
+++ b/test/pill_widget_test.dart
@@ -11,13 +11,20 @@ import 'package:pill/service/shared_preferences_service.dart';
 import 'package:pill/widget/pill_to_take_widget.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+class MockDateService extends DateService {
+  final DateTime mockDate;
+  MockDateService(this.mockDate);
+  @override
+  DateTime now() => mockDate;
+}
+
 void main() async {
   TestWidgetsFlutterBinding.ensureInitialized();
-  DateService dateService = DateService();
+  final DateTime date = DateTime(2026, 4, 4);
+  DateService dateService = MockDateService(date);
   SharedPreferences.setMockInitialValues({});
   SharedPreferencesService sharedPreferencesService =
       await SharedPreferencesService.create(dateService);
-  final DateTime date = DateTime(2026, 4, 4);
   String currentDateStorage = dateService.formatDateForStorage(date);
   String currentDateDisplay = dateService.formatDateForDisplay(date);
   String title = "You do not have to take any pills today 😀";
@@ -101,6 +108,7 @@ void main() async {
     context.read<PillBloc>().add(PillsEvent(
         eventName: PillEvent.addPill,
         date: currentDateStorage,
+        startDateTime: date,
         pillToTake: pillWithInfo));
 
     await tester.pumpAndSettle();
@@ -137,6 +145,7 @@ void main() async {
     context.read<PillBloc>().add(PillsEvent(
         eventName: PillEvent.addPill,
         date: currentDateStorage,
+        startDateTime: date,
         pillToTake: pillWithInfo));
 
     await tester.pumpAndSettle();
@@ -160,6 +169,7 @@ void main() async {
     context.read<PillBloc>().add(PillsEvent(
         eventName: PillEvent.addPill,
         date: currentDateStorage,
+        startDateTime: date,
         pillToTake: pillToTake));
 
     await tester.pumpAndSettle();

--- a/test/pill_widget_test.dart
+++ b/test/pill_widget_test.dart
@@ -17,9 +17,9 @@ void main() async {
   SharedPreferences.setMockInitialValues({});
   SharedPreferencesService sharedPreferencesService =
       await SharedPreferencesService.create(dateService);
-  final now = DateTime.now();
-  String currentDateStorage = dateService.formatDateForStorage(now);
-  String currentDateDisplay = dateService.formatDateForDisplay(now);
+  final DateTime date = DateTime(2026, 4, 4);
+  String currentDateStorage = dateService.formatDateForStorage(date);
+  String currentDateDisplay = dateService.formatDateForDisplay(date);
   String title = "You do not have to take any pills today 😀";
 
   setUp(() async {

--- a/test/pill_widget_test.dart
+++ b/test/pill_widget_test.dart
@@ -72,6 +72,7 @@ void main() async {
                                 child: PillWidget(
                                   pillToTake: state.pillsToTake![index],
                                   dateService: dateService,
+                                  date: date,
                                 ),
                                 onDismissed: (direction) {
                                   context.read<PillBloc>().add(PillsEvent(

--- a/test/pill_widget_test.dart
+++ b/test/pill_widget_test.dart
@@ -29,7 +29,7 @@ void main() async {
   Widget base = MultiBlocProvider(
       providers: [
         BlocProvider(
-            create: (context) => PillBloc(sharedPreferencesService)
+            create: (context) => PillBloc(sharedPreferencesService, dateService)
               ..add(PillsEvent(
                   eventName: PillEvent.loadPills, date: currentDateStorage))),
         BlocProvider(

--- a/test/pill_widget_test.dart
+++ b/test/pill_widget_test.dart
@@ -17,7 +17,8 @@ void main() async {
   SharedPreferences.setMockInitialValues({});
   SharedPreferencesService sharedPreferencesService =
       await SharedPreferencesService.create(dateService);
-  String currentDate = dateService.getDateAsYearMonthDay(DateTime.now());
+  String currentDateStorage = dateService.formatDateForStorage(DateTime.now());
+  String currentDateDisplay = dateService.formatDateForDisplay(DateTime.now());
   String title = "You do not have to take any pills today 😀";
 
   setUp(() async {
@@ -29,7 +30,7 @@ void main() async {
         BlocProvider(
             create: (context) => PillBloc(sharedPreferencesService)
               ..add(PillsEvent(
-                  eventName: PillEvent.loadPills, date: currentDate))),
+                  eventName: PillEvent.loadPills, date: currentDateStorage))),
         BlocProvider(
             create: (context) => ThemeBloc(sharedPreferencesService, false)),
         BlocProvider(
@@ -48,7 +49,7 @@ void main() async {
                   alignment: Alignment.topCenter,
                   child: Padding(
                     padding: const EdgeInsets.only(top: 40.0),
-                    child: Text(currentDate,
+                    child: Text(currentDateDisplay,
                         style: const TextStyle(
                             fontSize: 25.0, fontWeight: FontWeight.bold)),
                   ),
@@ -74,7 +75,7 @@ void main() async {
                                 onDismissed: (direction) {
                                   context.read<PillBloc>().add(PillsEvent(
                                       eventName: PillEvent.removePill,
-                                      date: currentDate,
+                                      date: currentDateStorage,
                                       pillToTake: state.pillsToTake![index]));
                                 })),
                       ))
@@ -97,7 +98,7 @@ void main() async {
     BuildContext context = tester.element(find.byType(Scaffold));
     context.read<PillBloc>().add(PillsEvent(
         eventName: PillEvent.addPill,
-        date: currentDate,
+        date: currentDateStorage,
         pillToTake: pillWithInfo));
 
     await tester.pumpAndSettle();
@@ -133,7 +134,7 @@ void main() async {
     BuildContext context = tester.element(find.byType(Scaffold));
     context.read<PillBloc>().add(PillsEvent(
         eventName: PillEvent.addPill,
-        date: currentDate,
+        date: currentDateStorage,
         pillToTake: pillWithInfo));
 
     await tester.pumpAndSettle();
@@ -156,7 +157,7 @@ void main() async {
     BuildContext context = tester.element(find.byType(Scaffold));
     context.read<PillBloc>().add(PillsEvent(
         eventName: PillEvent.addPill,
-        date: currentDate,
+        date: currentDateStorage,
         pillToTake: pillToTake));
 
     await tester.pumpAndSettle();

--- a/test/pill_widget_test.dart
+++ b/test/pill_widget_test.dart
@@ -17,8 +17,9 @@ void main() async {
   SharedPreferences.setMockInitialValues({});
   SharedPreferencesService sharedPreferencesService =
       await SharedPreferencesService.create(dateService);
-  String currentDateStorage = dateService.formatDateForStorage(DateTime.now());
-  String currentDateDisplay = dateService.formatDateForDisplay(DateTime.now());
+  final now = DateTime.now();
+  String currentDateStorage = dateService.formatDateForStorage(now);
+  String currentDateDisplay = dateService.formatDateForDisplay(now);
   String title = "You do not have to take any pills today 😀";
 
   setUp(() async {

--- a/test/pill_widget_test.dart
+++ b/test/pill_widget_test.dart
@@ -155,7 +155,7 @@ void main() async {
     await tester.pumpAndSettle();
 
     // If the pill was taken, it would be removed from the list (regiment 1 -> 0)
-    expect(find.text('Safe Pill'), findsOneWidget);
+    expect(find.text('safe pill'), findsOneWidget);
   });
 
   testWidgets("Pill Widget - Taking a Pill", (WidgetTester tester) async {
@@ -176,10 +176,10 @@ void main() async {
 
     // Tap the card (not the info icon)
     // Avoid tapping the top-right corner where the info icon might be (though not here)
-    await tester.tap(find.text('Action Pill')); 
+    await tester.tap(find.text('action pill')); 
     await tester.pumpAndSettle();
 
     // Pill should be gone as regiment is 0
-    expect(find.text('Action Pill'), findsNothing);
+    expect(find.text('action pill'), findsNothing);
   });
 }

--- a/test/pill_widget_test.dart
+++ b/test/pill_widget_test.dart
@@ -17,7 +17,7 @@ void main() async {
   SharedPreferences.setMockInitialValues({});
   SharedPreferencesService sharedPreferencesService =
       await SharedPreferencesService.create(dateService);
-  String currentDate = dateService.getDateAsMonthAndDay(DateTime.now());
+  String currentDate = dateService.getDateAsYearMonthDay(DateTime.now());
   String title = "You do not have to take any pills today 😀";
 
   setUp(() async {

--- a/test/pill_widget_test.dart
+++ b/test/pill_widget_test.dart
@@ -155,7 +155,7 @@ void main() async {
     await tester.pumpAndSettle();
 
     // If the pill was taken, it would be removed from the list (regiment 1 -> 0)
-    expect(find.text('safe pill'), findsOneWidget);
+    expect(find.text('Safe Pill'), findsOneWidget);
   });
 
   testWidgets("Pill Widget - Taking a Pill", (WidgetTester tester) async {
@@ -176,10 +176,10 @@ void main() async {
 
     // Tap the card (not the info icon)
     // Avoid tapping the top-right corner where the info icon might be (though not here)
-    await tester.tap(find.text('action pill')); 
+    await tester.tap(find.text('Action Pill')); 
     await tester.pumpAndSettle();
 
     // Pill should be gone as regiment is 0
-    expect(find.text('action pill'), findsNothing);
+    expect(find.text('Action Pill'), findsNothing);
   });
 }

--- a/test/shared_preferences_test.dart
+++ b/test/shared_preferences_test.dart
@@ -6,7 +6,7 @@ import 'package:pill/service/shared_preferences_service.dart';
 import 'package:pill/constants.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-void main() async {
+void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
   final DateService dateService = DateService();
   late SharedPreferencesService sharedPreferencesService;

--- a/test/shared_preferences_test.dart
+++ b/test/shared_preferences_test.dart
@@ -46,7 +46,7 @@ void main() {
     expect(pills.length, 1);
 
     List<PillToTake> found =
-        pills.where((element) => element.pillName == pill.pillName).toList();
+        pills.where((element) => element.pillName == pill.pillName.toLowerCase()).toList();
 
     expect(found.length, 1);
   });
@@ -193,6 +193,10 @@ void main() {
 
       final String pillsToTakeValue = PillToTake.encode([pill]);
       final String pillsTakenValue = PillTaken.encode([pillTaken]);
+      
+      final String migratedPillsValue = PillToTake.encode([pill.copyWith(pillName: pill.pillName.toLowerCase())]);
+      final String migratedTakenValue = PillTaken.encode([pillTaken.copyWith(pillName: pillTaken.pillName.toLowerCase())]);
+
       const String otherValue = "some_value";
       const int migrationYear = 2023;
 
@@ -210,9 +214,9 @@ void main() {
       SharedPreferences prefs = await SharedPreferences.getInstance();
 
       // Verify values were migrated correctly
-      expect(prefs.getString("$migrationYear/3/29"), pillsToTakeValue);
+      expect(prefs.getString("$migrationYear/3/29"), migratedPillsValue);
       expect(prefs.getString("$pillsTakenKey$migrationYear/3/29"),
-          pillsTakenValue);
+          migratedTakenValue);
 
       // Verify old keys were removed
       expect(prefs.containsKey("3/29"), false);
@@ -244,8 +248,8 @@ void main() {
       SharedPreferences.setMockInitialValues({
         "3/29": PillToTake.encode([pill1]),
         "pillsTaken3/29": PillTaken.encode([pillTaken1]),
-        "2026/3/29": PillToTake.encode([pill2]),
-        "pillsTaken2026/3/29": PillTaken.encode([pillTaken2]),
+        "2026/3/29": PillToTake.encode([pill2.copyWith(pillName: "pill b")]),
+        "pillsTaken2026/3/29": PillTaken.encode([pillTaken2.copyWith(pillName: "pill b")]),
         migratedToYearlyKeysKey: false,
       });
 
@@ -260,12 +264,12 @@ void main() {
           PillTaken.decode(prefs.getString("pillsTaken2026/3/29") ?? "");
 
       expect(migratedPills.length, 2);
-      expect(migratedPills.any((p) => p.pillName == "Pill A"), true);
-      expect(migratedPills.any((p) => p.pillName == "Pill B"), true);
+      expect(migratedPills.any((p) => p.pillName == "pill a"), true);
+      expect(migratedPills.any((p) => p.pillName == "pill b"), true);
 
       expect(migratedTaken.length, 2);
-      expect(migratedTaken.any((p) => p.pillName == "Pill A"), true);
-      expect(migratedTaken.any((p) => p.pillName == "Pill B"), true);
+      expect(migratedTaken.any((p) => p.pillName == "pill a"), true);
+      expect(migratedTaken.any((p) => p.pillName == "pill b"), true);
     });
   });
 }

--- a/test/shared_preferences_test.dart
+++ b/test/shared_preferences_test.dart
@@ -181,7 +181,7 @@ void main() async {
     
     // Verify values were migrated correctly
     expect(prefs.getString("$currentYear/3/29"), pillsToTakeValue);
-    expect(prefs.getString("${pillsTakenKey}$currentYear/3/29"), pillsTakenValue);
+    expect(prefs.getString("$pillsTakenKey$currentYear/3/29"), pillsTakenValue);
     
     // Verify old keys were removed
     expect(prefs.containsKey("3/29"), false);

--- a/test/shared_preferences_test.dart
+++ b/test/shared_preferences_test.dart
@@ -166,6 +166,7 @@ void main() async {
     const String pillsToTakeValue = "pillsToTakeData";
     const String pillsTakenValue = "pillsTakenData";
     const String otherValue = "some_value";
+    const int migrationYear = 2023;
 
     SharedPreferences.setMockInitialValues({
       "3/29": pillsToTakeValue,
@@ -173,15 +174,14 @@ void main() async {
       "some_other_key": otherValue
     });
     
-    // Create a new service instance to trigger migration
-    await SharedPreferencesService.create(dateService);
+    // Create a new service instance to trigger migration with a fixed year
+    await SharedPreferencesService.create(dateService, migrationYear: migrationYear);
     
-    final currentYear = DateTime.now().year;
     SharedPreferences prefs = await SharedPreferences.getInstance();
     
     // Verify values were migrated correctly
-    expect(prefs.getString("$currentYear/3/29"), pillsToTakeValue);
-    expect(prefs.getString("$pillsTakenKey$currentYear/3/29"), pillsTakenValue);
+    expect(prefs.getString("$migrationYear/3/29"), pillsToTakeValue);
+    expect(prefs.getString("$pillsTakenKey$migrationYear/3/29"), pillsTakenValue);
     
     // Verify old keys were removed
     expect(prefs.containsKey("3/29"), false);

--- a/test/shared_preferences_test.dart
+++ b/test/shared_preferences_test.dart
@@ -11,7 +11,7 @@ void main() async {
   final DateService dateService = DateService();
   late SharedPreferencesService sharedPreferencesService;
   final DateTime now = DateTime.now();
-  final String date = dateService.getDateAsYearMonthDay(now);
+  final String date = dateService.formatDateForStorage(now);
 
   setUp(() async {
     // Reset SharedPreferences before each test

--- a/test/shared_preferences_test.dart
+++ b/test/shared_preferences_test.dart
@@ -163,22 +163,34 @@ void main() async {
   });
 
   test("SharedPreferences Service migration", () async {
+    const String pillsToTakeValue = "pillsToTakeData";
+    const String pillsTakenValue = "pillsTakenData";
+    const String otherValue = "some_value";
+
     SharedPreferences.setMockInitialValues({
-      "3/29": "[]",
-      "pillsTaken3/29": "[]",
-      "some_other_key": "some_value"
+      "3/29": pillsToTakeValue,
+      "pillsTaken3/29": pillsTakenValue,
+      "some_other_key": otherValue
     });
     
-    SharedPreferencesService migratedService = await SharedPreferencesService.create(dateService);
+    // Create a new service instance to trigger migration
+    await SharedPreferencesService.create(dateService);
+    
     final currentYear = DateTime.now().year;
-    
-    expect(migratedService.getPillsToTakeForDate("$currentYear/3/29"), isA<List<PillToTake>>());
-    expect(migratedService.getPillsTakenForDate("$currentYear/3/29"), isA<List<PillTaken>>());
-    
     SharedPreferences prefs = await SharedPreferences.getInstance();
+    
+    // Verify values were migrated correctly
+    expect(prefs.getString("$currentYear/3/29"), pillsToTakeValue);
+    expect(prefs.getString("${pillsTakenKey}$currentYear/3/29"), pillsTakenValue);
+    
+    // Verify old keys were removed
     expect(prefs.containsKey("3/29"), false);
     expect(prefs.containsKey("pillsTaken3/29"), false);
-    expect(prefs.getString("some_other_key"), "some_value");
+    
+    // Verify unrelated keys were preserved
+    expect(prefs.getString("some_other_key"), otherValue);
+    
+    // Verify migration flag was set
     expect(prefs.getBool(migratedToYearlyKeysKey), true);
   });
 }

--- a/test/shared_preferences_test.dart
+++ b/test/shared_preferences_test.dart
@@ -6,14 +6,23 @@ import 'package:pill/service/shared_preferences_service.dart';
 import 'package:pill/constants.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+class TestDateService extends DateService {
+  @override
+  DateTime now() => DateTime(2024, 1, 1, 12, 0);
+}
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
-  final DateService dateService = DateService();
+  late DateService dateService;
   late SharedPreferencesService sharedPreferencesService;
-  final DateTime now = DateTime.now();
-  final String date = dateService.formatDateForStorage(now);
+  late DateTime fixedNow;
+  late String fixedDate;
 
   setUp(() async {
+    dateService = TestDateService();
+    fixedNow = dateService.now();
+    fixedDate = dateService.formatDateForStorage(fixedNow);
+    
     // Reset SharedPreferences before each test
     SharedPreferences.setMockInitialValues({});
     sharedPreferencesService =
@@ -23,16 +32,16 @@ void main() {
   test("SharedPreferences Service get pills for date (where no pills exist)",
       () {
     List<PillToTake> pills =
-        sharedPreferencesService.getPillsToTakeForDate(date);
+        sharedPreferencesService.getPillsToTakeForDate(fixedDate);
     expect(pills.length, 0);
   });
 
   test("SharedPreferences Service add pill to date", () {
     const PillToTake pill = PillToTake(
         pillName: "Test Pill", pillRegiment: 2, amountOfDaysToTake: 1);
-    sharedPreferencesService.addPillToDates(now, pill);
+    sharedPreferencesService.addPillToDates(fixedNow, pill);
     List<PillToTake> pills =
-        sharedPreferencesService.getPillsToTakeForDate(date);
+        sharedPreferencesService.getPillsToTakeForDate(fixedDate);
 
     expect(pills.length, 1);
 
@@ -45,15 +54,15 @@ void main() {
   test("SharedPreferences Service remove pill from date", () {
     const PillToTake pill = PillToTake(
         pillName: "Test Pill", pillRegiment: 2, amountOfDaysToTake: 1);
-    sharedPreferencesService.addPillToDates(now, pill);
+    sharedPreferencesService.addPillToDates(fixedNow, pill);
     List<PillToTake> pills =
-        sharedPreferencesService.getPillsToTakeForDate(date);
+        sharedPreferencesService.getPillsToTakeForDate(fixedDate);
 
     expect(pills.length, 1);
 
-    sharedPreferencesService.removePillFromDate(pill, date);
+    sharedPreferencesService.removePillFromDate(pill, fixedDate);
 
-    pills = sharedPreferencesService.getPillsToTakeForDate(date);
+    pills = sharedPreferencesService.getPillsToTakeForDate(fixedDate);
 
     expect(pills.length, 0);
   });
@@ -63,33 +72,33 @@ void main() {
       () {
     const PillToTake pill = PillToTake(
         pillName: "Test Pill", pillRegiment: 2, amountOfDaysToTake: 1);
-    sharedPreferencesService.addPillToDates(now, pill);
+    sharedPreferencesService.addPillToDates(fixedNow, pill);
 
     // Attempt removal with different casing and whitespace
     const PillToTake pillToRemove = PillToTake(
         pillName: "  test pill  ", pillRegiment: 2, amountOfDaysToTake: 1);
 
-    sharedPreferencesService.removePillFromDate(pillToRemove, date);
+    sharedPreferencesService.removePillFromDate(pillToRemove, fixedDate);
 
     List<PillToTake> pills =
-        sharedPreferencesService.getPillsToTakeForDate(date);
+        sharedPreferencesService.getPillsToTakeForDate(fixedDate);
     expect(pills.length, 0);
   });
 
   test("SharedPreferences Service update pill from date", () {
     const PillToTake pill = PillToTake(
         pillName: "Test Pill", pillRegiment: 2, amountOfDaysToTake: 1);
-    sharedPreferencesService.addPillToDates(now, pill);
+    sharedPreferencesService.addPillToDates(fixedNow, pill);
     List<PillToTake> pills =
-        sharedPreferencesService.getPillsToTakeForDate(date);
+        sharedPreferencesService.getPillsToTakeForDate(fixedDate);
 
     expect(pills.length, 1);
 
     final PillToTake updatedPillInstance = pill.copyWith(pillRegiment: 10);
 
-    sharedPreferencesService.updatePillForDate(updatedPillInstance, date);
+    sharedPreferencesService.updatePillForDate(updatedPillInstance, fixedDate);
 
-    pills = sharedPreferencesService.getPillsToTakeForDate(date);
+    pills = sharedPreferencesService.getPillsToTakeForDate(fixedDate);
 
     PillToTake updatedPill = pills[0];
 
@@ -101,16 +110,16 @@ void main() {
       () {
     const PillToTake pill = PillToTake(
         pillName: "Test Pill", pillRegiment: 2, amountOfDaysToTake: 1);
-    sharedPreferencesService.addPillToDates(now, pill);
+    sharedPreferencesService.addPillToDates(fixedNow, pill);
 
     // Update with different casing and whitespace
     const PillToTake updatedPillInstance = PillToTake(
         pillName: "  test pill  ", pillRegiment: 10, amountOfDaysToTake: 1);
 
-    sharedPreferencesService.updatePillForDate(updatedPillInstance, date);
+    sharedPreferencesService.updatePillForDate(updatedPillInstance, fixedDate);
 
     List<PillToTake> pills =
-        sharedPreferencesService.getPillsToTakeForDate(date);
+        sharedPreferencesService.getPillsToTakeForDate(fixedDate);
     expect(pills.length, 1);
     expect(pills[0].pillRegiment, 10);
   });
@@ -122,14 +131,14 @@ void main() {
         pillName: "Non Existent Pill", pillRegiment: 2, amountOfDaysToTake: 1);
 
     // This should not throw RangeError
-    sharedPreferencesService.updatePillForDate(pill, date);
+    sharedPreferencesService.updatePillForDate(pill, fixedDate);
 
     List<PillToTake> pills =
-        sharedPreferencesService.getPillsToTakeForDate(date);
+        sharedPreferencesService.getPillsToTakeForDate(fixedDate);
     expect(pills.length, 0);
 
     List<PillTaken> pillsTaken =
-        sharedPreferencesService.getPillsTakenForDate(date);
+        sharedPreferencesService.getPillsTakenForDate(fixedDate);
     // Verification: No entry should be added for a pill not in the schedule
     expect(pillsTaken.length, 0);
   });
@@ -142,24 +151,24 @@ void main() {
         amountOfDaysToTake: 1,
         pillImage: customImage);
 
-    sharedPreferencesService.addPillToDates(now, pill);
+    sharedPreferencesService.addPillToDates(fixedNow, pill);
 
     List<PillToTake> pills =
-        sharedPreferencesService.getPillsToTakeForDate(date);
+        sharedPreferencesService.getPillsToTakeForDate(fixedDate);
     expect(pills[0].pillImage, customImage);
 
-    sharedPreferencesService.updatePillForDate(pill, date);
+    sharedPreferencesService.updatePillForDate(pill, fixedDate);
     List<PillTaken> pillsTaken =
-        sharedPreferencesService.getPillsTakenForDate(date);
+        sharedPreferencesService.getPillsTakenForDate(fixedDate);
     expect(pillsTaken[0].pillImage, customImage);
   });
 
   test("SharedPreferences Service Clearing All Pills", () {
     const PillToTake pill = PillToTake(
         pillName: "Test Pill", pillRegiment: 2, amountOfDaysToTake: 1);
-    sharedPreferencesService.addPillToDates(now, pill);
+    sharedPreferencesService.addPillToDates(fixedNow, pill);
     List<PillToTake> pills =
-        sharedPreferencesService.getPillsToTakeForDate(date);
+        sharedPreferencesService.getPillsToTakeForDate(fixedDate);
 
     expect(pills.length, 1);
 

--- a/test/shared_preferences_test.dart
+++ b/test/shared_preferences_test.dart
@@ -3,6 +3,7 @@ import 'package:pill/model/pill_to_take.dart';
 import 'package:pill/model/pill_taken.dart';
 import 'package:pill/service/date_service.dart';
 import 'package:pill/service/shared_preferences_service.dart';
+import 'package:pill/constants.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 void main() async {
@@ -159,5 +160,25 @@ void main() async {
     areTherePillsToTake = sharedPreferencesService.areThereAnyPillsToTake();
 
     expect(areTherePillsToTake, false);
+  });
+
+  test("SharedPreferences Service migration", () async {
+    SharedPreferences.setMockInitialValues({
+      "3/29": "[]",
+      "pillsTaken3/29": "[]",
+      "some_other_key": "some_value"
+    });
+    
+    SharedPreferencesService migratedService = await SharedPreferencesService.create(dateService);
+    final currentYear = DateTime.now().year;
+    
+    expect(migratedService.getPillsToTakeForDate("$currentYear/3/29"), isA<List<PillToTake>>());
+    expect(migratedService.getPillsTakenForDate("$currentYear/3/29"), isA<List<PillTaken>>());
+    
+    SharedPreferences prefs = await SharedPreferences.getInstance();
+    expect(prefs.containsKey("3/29"), false);
+    expect(prefs.containsKey("pillsTaken3/29"), false);
+    expect(prefs.getString("some_other_key"), "some_value");
+    expect(prefs.getBool(migratedToYearlyKeysKey), true);
   });
 }

--- a/test/shared_preferences_test.dart
+++ b/test/shared_preferences_test.dart
@@ -13,7 +13,7 @@ void main() async {
   SharedPreferencesService sharedPreferencesService =
       await SharedPreferencesService.create(dateService);
   final DateTime now = DateTime.now();
-  final String date = DateService().getDateAsMonthAndDay(now);
+  final String date = DateService().getDateAsYearMonthDay(now);
 
   setUp(() {
     sharedPreferencesService.clearAllPills();

--- a/test/shared_preferences_test.dart
+++ b/test/shared_preferences_test.dart
@@ -46,7 +46,7 @@ void main() {
     expect(pills.length, 1);
 
     List<PillToTake> found =
-        pills.where((element) => element.pillName == pill.pillName.toLowerCase()).toList();
+        pills.where((element) => element.pillName == pill.pillName).toList();
 
     expect(found.length, 1);
   });
@@ -194,8 +194,8 @@ void main() {
       final String pillsToTakeValue = PillToTake.encode([pill]);
       final String pillsTakenValue = PillTaken.encode([pillTaken]);
       
-      final String migratedPillsValue = PillToTake.encode([pill.copyWith(pillName: pill.pillName.toLowerCase())]);
-      final String migratedTakenValue = PillTaken.encode([pillTaken.copyWith(pillName: pillTaken.pillName.toLowerCase())]);
+      final String migratedPillsValue = PillToTake.encode([pill]);
+      final String migratedTakenValue = PillTaken.encode([pillTaken]);
 
       const String otherValue = "some_value";
       const int migrationYear = 2023;
@@ -248,8 +248,8 @@ void main() {
       SharedPreferences.setMockInitialValues({
         "3/29": PillToTake.encode([pill1]),
         "pillsTaken3/29": PillTaken.encode([pillTaken1]),
-        "2026/3/29": PillToTake.encode([pill2.copyWith(pillName: "pill b")]),
-        "pillsTaken2026/3/29": PillTaken.encode([pillTaken2.copyWith(pillName: "pill b")]),
+        "2026/3/29": PillToTake.encode([pill2.copyWith(pillName: "Pill B")]),
+        "pillsTaken2026/3/29": PillTaken.encode([pillTaken2.copyWith(pillName: "Pill B")]),
         migratedToYearlyKeysKey: false,
       });
 
@@ -264,12 +264,12 @@ void main() {
           PillTaken.decode(prefs.getString("pillsTaken2026/3/29") ?? "");
 
       expect(migratedPills.length, 2);
-      expect(migratedPills.any((p) => p.pillName == "pill a"), true);
-      expect(migratedPills.any((p) => p.pillName == "pill b"), true);
+      expect(migratedPills.any((p) => p.pillName == "Pill A"), true);
+      expect(migratedPills.any((p) => p.pillName == "Pill B"), true);
 
       expect(migratedTaken.length, 2);
-      expect(migratedTaken.any((p) => p.pillName == "pill a"), true);
-      expect(migratedTaken.any((p) => p.pillName == "pill b"), true);
+      expect(migratedTaken.any((p) => p.pillName == "Pill A"), true);
+      expect(migratedTaken.any((p) => p.pillName == "Pill B"), true);
     });
   });
 }

--- a/test/shared_preferences_test.dart
+++ b/test/shared_preferences_test.dart
@@ -8,15 +8,16 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 void main() async {
   TestWidgetsFlutterBinding.ensureInitialized();
-  DateService dateService = DateService();
-  SharedPreferences.setMockInitialValues({});
-  SharedPreferencesService sharedPreferencesService =
-      await SharedPreferencesService.create(dateService);
+  final DateService dateService = DateService();
+  late SharedPreferencesService sharedPreferencesService;
   final DateTime now = DateTime.now();
-  final String date = DateService().getDateAsYearMonthDay(now);
+  final String date = dateService.getDateAsYearMonthDay(now);
 
-  setUp(() {
-    sharedPreferencesService.clearAllPills();
+  setUp(() async {
+    // Reset SharedPreferences before each test
+    SharedPreferences.setMockInitialValues({});
+    sharedPreferencesService =
+        await SharedPreferencesService.create(dateService);
   });
 
   test("SharedPreferences Service get pills for date (where no pills exist)",
@@ -57,18 +58,21 @@ void main() async {
     expect(pills.length, 0);
   });
 
-  test("SharedPreferences Service remove pill from date (case-insensitive and trimmed)", () {
+  test(
+      "SharedPreferences Service remove pill from date (case-insensitive and trimmed)",
+      () {
     const PillToTake pill = PillToTake(
         pillName: "Test Pill", pillRegiment: 2, amountOfDaysToTake: 1);
     sharedPreferencesService.addPillToDates(now, pill);
-    
+
     // Attempt removal with different casing and whitespace
     const PillToTake pillToRemove = PillToTake(
         pillName: "  test pill  ", pillRegiment: 2, amountOfDaysToTake: 1);
-    
+
     sharedPreferencesService.removePillFromDate(pillToRemove, date);
 
-    List<PillToTake> pills = sharedPreferencesService.getPillsToTakeForDate(date);
+    List<PillToTake> pills =
+        sharedPreferencesService.getPillsToTakeForDate(date);
     expect(pills.length, 0);
   });
 
@@ -92,33 +96,40 @@ void main() async {
     expect(updatedPill.pillRegiment, 10);
   });
 
-  test("SharedPreferences Service update pill from date (case-insensitive and trimmed)", () {
+  test(
+      "SharedPreferences Service update pill from date (case-insensitive and trimmed)",
+      () {
     const PillToTake pill = PillToTake(
         pillName: "Test Pill", pillRegiment: 2, amountOfDaysToTake: 1);
     sharedPreferencesService.addPillToDates(now, pill);
-    
+
     // Update with different casing and whitespace
     const PillToTake updatedPillInstance = PillToTake(
         pillName: "  test pill  ", pillRegiment: 10, amountOfDaysToTake: 1);
 
     sharedPreferencesService.updatePillForDate(updatedPillInstance, date);
 
-    List<PillToTake> pills = sharedPreferencesService.getPillsToTakeForDate(date);
+    List<PillToTake> pills =
+        sharedPreferencesService.getPillsToTakeForDate(date);
     expect(pills.length, 1);
     expect(pills[0].pillRegiment, 10);
   });
 
-  test("SharedPreferences Service update pill from date - pill not found guard", () {
+  test(
+      "SharedPreferences Service update pill from date - pill not found guard",
+      () {
     const PillToTake pill = PillToTake(
         pillName: "Non Existent Pill", pillRegiment: 2, amountOfDaysToTake: 1);
-    
+
     // This should not throw RangeError
     sharedPreferencesService.updatePillForDate(pill, date);
-    
-    List<PillToTake> pills = sharedPreferencesService.getPillsToTakeForDate(date);
+
+    List<PillToTake> pills =
+        sharedPreferencesService.getPillsToTakeForDate(date);
     expect(pills.length, 0);
-    
-    List<PillTaken> pillsTaken = sharedPreferencesService.getPillsTakenForDate(date);
+
+    List<PillTaken> pillsTaken =
+        sharedPreferencesService.getPillsTakenForDate(date);
     // Verification: No entry should be added for a pill not in the schedule
     expect(pillsTaken.length, 0);
   });
@@ -126,18 +137,20 @@ void main() async {
   test("SharedPreferences Service pillImage persistence", () {
     const String customImage = "assets/images/custom_pill.png";
     const PillToTake pill = PillToTake(
-        pillName: "Custom Image Pill", 
-        pillRegiment: 2, 
+        pillName: "Custom Image Pill",
+        pillRegiment: 2,
         amountOfDaysToTake: 1,
         pillImage: customImage);
-    
+
     sharedPreferencesService.addPillToDates(now, pill);
-    
-    List<PillToTake> pills = sharedPreferencesService.getPillsToTakeForDate(date);
+
+    List<PillToTake> pills =
+        sharedPreferencesService.getPillsToTakeForDate(date);
     expect(pills[0].pillImage, customImage);
-    
+
     sharedPreferencesService.updatePillForDate(pill, date);
-    List<PillTaken> pillsTaken = sharedPreferencesService.getPillsTakenForDate(date);
+    List<PillTaken> pillsTaken =
+        sharedPreferencesService.getPillsTakenForDate(date);
     expect(pillsTaken[0].pillImage, customImage);
   });
 
@@ -162,35 +175,88 @@ void main() async {
     expect(areTherePillsToTake, false);
   });
 
-  test("SharedPreferences Service migration", () async {
-    const String pillsToTakeValue = "pillsToTakeData";
-    const String pillsTakenValue = "pillsTakenData";
-    const String otherValue = "some_value";
-    const int migrationYear = 2023;
+  group("SharedPreferences Service migration", () {
+    test("Standard migration", () async {
+      const pill = PillToTake(
+          pillName: "Test Pill", pillRegiment: 1, amountOfDaysToTake: 1);
+      final pillTaken = PillTaken(
+          pillName: "Test Pill", lastTaken: DateTime(2023, 3, 29, 10));
 
-    SharedPreferences.setMockInitialValues({
-      "3/29": pillsToTakeValue,
-      "pillsTaken3/29": pillsTakenValue,
-      "some_other_key": otherValue
+      final String pillsToTakeValue = PillToTake.encode([pill]);
+      final String pillsTakenValue = PillTaken.encode([pillTaken]);
+      const String otherValue = "some_value";
+      const int migrationYear = 2023;
+
+      SharedPreferences.setMockInitialValues({
+        "3/29": pillsToTakeValue,
+        "pillsTaken3/29": pillsTakenValue,
+        "some_other_key": otherValue,
+        migratedToYearlyKeysKey: false,
+      });
+
+      // Create a new service instance to trigger migration with a fixed year
+      await SharedPreferencesService.create(dateService,
+          migrationYear: migrationYear);
+
+      SharedPreferences prefs = await SharedPreferences.getInstance();
+
+      // Verify values were migrated correctly
+      expect(prefs.getString("$migrationYear/3/29"), pillsToTakeValue);
+      expect(prefs.getString("$pillsTakenKey$migrationYear/3/29"),
+          pillsTakenValue);
+
+      // Verify old keys were removed
+      expect(prefs.containsKey("3/29"), false);
+      expect(prefs.containsKey("pillsTaken3/29"), false);
+
+      // Verify unrelated keys were preserved
+      expect(prefs.getString("some_other_key"), otherValue);
+
+      // Verify migration flag was set
+      expect(prefs.getBool(migratedToYearlyKeysKey), true);
     });
-    
-    // Create a new service instance to trigger migration with a fixed year
-    await SharedPreferencesService.create(dateService, migrationYear: migrationYear);
-    
-    SharedPreferences prefs = await SharedPreferences.getInstance();
-    
-    // Verify values were migrated correctly
-    expect(prefs.getString("$migrationYear/3/29"), pillsToTakeValue);
-    expect(prefs.getString("$pillsTakenKey$migrationYear/3/29"), pillsTakenValue);
-    
-    // Verify old keys were removed
-    expect(prefs.containsKey("3/29"), false);
-    expect(prefs.containsKey("pillsTaken3/29"), false);
-    
-    // Verify unrelated keys were preserved
-    expect(prefs.getString("some_other_key"), otherValue);
-    
-    // Verify migration flag was set
-    expect(prefs.getBool(migratedToYearlyKeysKey), true);
+
+    test("Migration with conflict resolution (merge data)", () async {
+      const int migrationYear = 2026;
+      const pill1 = PillToTake(
+          pillName: "Pill A", pillRegiment: 1, amountOfDaysToTake: 7);
+      const pill2 = PillToTake(
+          pillName: "Pill B", pillRegiment: 2, amountOfDaysToTake: 7);
+
+      final pillTaken1 = PillTaken(
+          pillName: "Pill A",
+          lastTaken: DateTime(2026, 3, 29, 10),
+          pillImage: "img1");
+      final pillTaken2 = PillTaken(
+          pillName: "Pill B",
+          lastTaken: DateTime(2026, 3, 29, 11),
+          pillImage: "img2");
+
+      SharedPreferences.setMockInitialValues({
+        "3/29": PillToTake.encode([pill1]),
+        "pillsTaken3/29": PillTaken.encode([pillTaken1]),
+        "2026/3/29": PillToTake.encode([pill2]),
+        "pillsTaken2026/3/29": PillTaken.encode([pillTaken2]),
+        migratedToYearlyKeysKey: false,
+      });
+
+      await SharedPreferencesService.create(dateService,
+          migrationYear: migrationYear);
+
+      final prefs = await SharedPreferences.getInstance();
+
+      final migratedPills =
+          PillToTake.decode(prefs.getString("2026/3/29") ?? "");
+      final migratedTaken =
+          PillTaken.decode(prefs.getString("pillsTaken2026/3/29") ?? "");
+
+      expect(migratedPills.length, 2);
+      expect(migratedPills.any((p) => p.pillName == "Pill A"), true);
+      expect(migratedPills.any((p) => p.pillName == "Pill B"), true);
+
+      expect(migratedTaken.length, 2);
+      expect(migratedTaken.any((p) => p.pillName == "Pill A"), true);
+      expect(migratedTaken.any((p) => p.pillName == "Pill B"), true);
+    });
   });
 }

--- a/test/shared_preferences_test.dart
+++ b/test/shared_preferences_test.dart
@@ -195,7 +195,7 @@ void main() async {
       });
 
       // Create a new service instance to trigger migration with a fixed year
-      await SharedPreferencesService.create(dateService,
+      await SharedPreferencesService.createForTesting(dateService,
           migrationYear: migrationYear);
 
       SharedPreferences prefs = await SharedPreferences.getInstance();
@@ -240,7 +240,7 @@ void main() async {
         migratedToYearlyKeysKey: false,
       });
 
-      await SharedPreferencesService.create(dateService,
+      await SharedPreferencesService.createForTesting(dateService,
           migrationYear: migrationYear);
 
       final prefs = await SharedPreferences.getInstance();


### PR DESCRIPTION
Fixes #75 

This pull request introduces significant improvements to date handling and data migration in the application. The main changes include a migration of storage keys from a "month/day" format to a "year/month/day" format, a new `DateService` API for consistent date manipulation, and updates to the UI to ensure the correct date is always displayed and used. Additionally, the `SharedPreferencesService` now handles legacy data migration and offers improved testability.

**Data Model and Storage Migration:**

* Added a migration process in `SharedPreferencesService` to convert legacy storage keys from "M/D" to "YYYY/M/D" format, ensuring data integrity across years and preventing key collisions. This includes logic to merge or deduplicate pills as needed and a persistent flag (`migratedToYearlyKeysKey`) to prevent repeated migrations. 

* Updated all data access and mutation methods in `SharedPreferencesService` to use the new date key format via `DateService.formatDateForStorage`, and ensured non-pill keys are skipped during migration and clear operations. 

**Date Handling and Consistency:**

* Introduced a new `DateService` API with methods for obtaining the current date/time and formatting dates for storage and display, replacing ad-hoc usages of `DateTime.now()` throughout the codebase. Deprecated old methods in favor of the new API. 

* Updated `PillBloc`, `MainPage`, and related widgets to use `DateService` for all date calculations and storage, ensuring consistency and easier testing.

**UI and UX Improvements:**

* Refactored `MainPage` to track and update the current date via `DateService`, including scheduling a timer to refresh the UI at midnight and responding to app lifecycle changes to reload the correct day's data.

* Updated `AddingPillForm` to accept an explicit `pillDate` and `DateService`, ensuring new pills are always added for the correct date, even if the app is opened at midnight or after a date change. 

**Testability Enhancements:**

* Added a `createForTesting` method to `SharedPreferencesService` to facilitate testing with custom dates and migration years.

These changes collectively improve data correctness across years, make date handling more robust and testable, and enhance the user experience by always reflecting the correct day's data in the UI.