### PR TITLE
addPillToDates stores the same PillToTake object reference across multiple days

### DIFF
--- a/lib/service/shared_preferences_service.dart
+++ b/lib/service/shared_preferences_service.dart
@@ -207,7 +207,7 @@ class SharedPreferencesService {
     while (daysToTake > 0) {
       String dateStr = _dateService.formatDateForStorage(runningDate);
       List<PillToTake> pills = getPillsToTakeForDate(dateStr);
-      pills.add(pillWithTrimmedName);
+      pills.add(pillWithTrimmedName.copyWith());
       _setPillsForDate(dateStr, pills);
       runningDate = runningDate.add(const Duration(days: oneDay));
       daysToTake--;


### PR DESCRIPTION
Fixes #76 

This pull request makes a small adjustment to how pills are added to the list for a given date in the `SharedPreferencesService` class. Instead of adding the original `pillWithTrimmedName` object directly, it now adds a copy using the `copyWith()` method. This approach helps avoid potential side effects from shared references to the same object.