### PR TITLE
areThereAnyPillsToTake uses a fragile regex to identify date keys

### DIFF
--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -23,6 +23,8 @@ const String pillsTakenHeader = "You have not taken any pills today";
 
 //SharedPreferences Keys
 const String pillsTakenKey = "pillsTaken";
+const String pillsToTakeKey = "pillsToTake";
 const String timeAppOpenedKey = "timeAppOpened";
 const String darkModeKey = "darkMode";
 const String migratedToYearlyKeysKey = "migratedToYearlyKeys";
+const String migratedToPrefixedKeysKey = "migratedToPrefixedKeys";

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -22,9 +22,10 @@ const String pillsToTakeHeader =
 const String pillsTakenHeader = "You have not taken any pills today";
 
 //SharedPreferences Keys
-const String pillsTakenKey = "pillsTaken";
-const String pillsToTakeKey = "pillsToTake";
+const String pillsTakenPrefix = "pillsTaken_";
+const String pillsToTakePrefix = "pillsToTake_";
 const String timeAppOpenedKey = "timeAppOpened";
 const String darkModeKey = "darkMode";
 const String migratedToYearlyKeysKey = "migratedToYearlyKeys";
 const String migratedToPrefixedKeysKey = "migratedToPrefixedKeys";
+const String migratedToDelimiterKeysKey = "migratedToDelimiterKeys";

--- a/lib/service/shared_preferences_service.dart
+++ b/lib/service/shared_preferences_service.dart
@@ -217,6 +217,17 @@ class SharedPreferencesService {
             String migratedValue;
             if (existingValue != null) {
               final legacyPills = PillToTake.decode(legacyValue)
+      try {
+        // Identify keys that are YYYY/M/D (already migrated to yearly format but not yet prefixed)
+        if (RegExp(r'^\d{4}/\d{1,2}/\d{1,2}$').hasMatch(key)) {
+          final legacyValue = _sharedPreferences.getString(key);
+          if (legacyValue != null) {
+            final targetKey = "$legacyToTakeKey$key";
+            final existingValue = _sharedPreferences.getString(targetKey);
+
+            String migratedValue;
+            if (existingValue != null) {
+              final legacyPills = PillToTake.decode(legacyValue)
                   .map((p) => p.copyWith(pillName: p.pillName.trim()))
                   .toList();
               final existingPills = PillToTake.decode(existingValue)
@@ -237,8 +248,7 @@ class SharedPreferencesService {
 
             if (await _sharedPreferences.setString(targetKey, migratedValue)) {
               if (!(await _sharedPreferences.remove(key))) {
-                log(
-                    "Failed to remove non-prefixed key '$key' after migration to '$targetKey'",
+                log("Failed to remove non-prefixed key '$key' after migration to '$targetKey'",
                     level: 1000);
                 allSucceeded = false;
               }
@@ -246,16 +256,17 @@ class SharedPreferencesService {
               log("Failed to write prefixed key '$targetKey'", level: 1000);
               allSucceeded = false;
             }
-          } catch (e, s) {
-            log(
-              "Failed to migrate non-prefixed key '$key' to prefixed format",
-              error: e,
-              stackTrace: s,
-              level: 1000,
-            );
-            allSucceeded = false;
           }
         }
+      } catch (e, stackTrace) {
+        final legacyValue = _sharedPreferences.getString(key);
+        log(
+          "Failed to migrate non-prefixed key '$key' with value '$legacyValue'",
+          error: e,
+          stackTrace: stackTrace,
+          level: 1000,
+        );
+        allSucceeded = false;
       }
     }
 

--- a/lib/service/shared_preferences_service.dart
+++ b/lib/service/shared_preferences_service.dart
@@ -178,6 +178,12 @@ class SharedPreferencesService {
   }
 
   Future<void> _migrateToPrefixedKeys() async {
+    final migratedToYearly =
+        _sharedPreferences.getBool(migratedToYearlyKeysKey) ?? false;
+    if (!migratedToYearly) {
+      return;
+    }
+
     if (_sharedPreferences.getBool(migratedToPrefixedKeysKey) ?? false) {
       return;
     }

--- a/lib/service/shared_preferences_service.dart
+++ b/lib/service/shared_preferences_service.dart
@@ -43,6 +43,11 @@ class SharedPreferencesService {
   }
 
   Future<void> _migrateKeys({int? migrationYear}) async {
+    await _migrateToYearlyKeys(migrationYear: migrationYear);
+    await _migrateToPrefixedKeys();
+  }
+
+  Future<void> _migrateToYearlyKeys({int? migrationYear}) async {
     if (_sharedPreferences.getBool(migratedToYearlyKeysKey) ?? false) {
       return;
     }
@@ -54,7 +59,8 @@ class SharedPreferencesService {
     for (String key in keys) {
       if (key == timeAppOpenedKey ||
           key == darkModeKey ||
-          key == migratedToYearlyKeysKey) {
+          key == migratedToYearlyKeysKey ||
+          key == migratedToPrefixedKeysKey) {
         continue;
       }
 
@@ -167,13 +173,58 @@ class SharedPreferencesService {
     }
   }
 
+  Future<void> _migrateToPrefixedKeys() async {
+    if (_sharedPreferences.getBool(migratedToPrefixedKeysKey) ?? false) {
+      return;
+    }
+
+    final keys = _sharedPreferences.getKeys().toList();
+    bool allSucceeded = true;
+
+    for (String key in keys) {
+      if (key == timeAppOpenedKey ||
+          key == darkModeKey ||
+          key == migratedToYearlyKeysKey ||
+          key == migratedToPrefixedKeysKey ||
+          key.startsWith(pillsTakenKey) ||
+          key.startsWith(pillsToTakeKey)) {
+        continue;
+      }
+
+      // Identify keys that are YYYY/M/D (already migrated to yearly format but not yet prefixed)
+      if (RegExp(r'^\d{4}/\d{1,2}/\d{1,2}$').hasMatch(key)) {
+        final value = _sharedPreferences.getString(key);
+        if (value != null) {
+          final targetKey = "$pillsToTakeKey$key";
+          if (await _sharedPreferences.setString(targetKey, value)) {
+            if (!(await _sharedPreferences.remove(key))) {
+              log("Failed to remove non-prefixed key '$key' after migration to '$targetKey'",
+                  level: 1000);
+              allSucceeded = false;
+            }
+          } else {
+            log("Failed to write prefixed key '$targetKey'", level: 1000);
+            allSucceeded = false;
+          }
+        }
+      }
+    }
+
+    if (allSucceeded) {
+      if (!(await _sharedPreferences.setBool(migratedToPrefixedKeysKey, true))) {
+        log("Failed to set migration completion flag '$migratedToPrefixedKeysKey'",
+            level: 1000);
+      }
+    }
+  }
+
   // The Future returned by SharedPreferences write methods is intentionally
   // unawaited: SharedPreferences commits writes to its in-memory cache
   // synchronously before the Future resolves, so subsequent reads on the same
   // instance always see the updated value immediately.
-  void _setPillsForDate(String currentDate, List<PillToTake> pills) {
-    unawaited(
-        _sharedPreferences.setString(currentDate, PillToTake.encode(pills)));
+  void _setPillsForDate(String date, List<PillToTake> pills) {
+    unawaited(_sharedPreferences.setString(
+        pillsToTakeKey + date, PillToTake.encode(pills)));
   }
 
   void _setPillsTakenForDate(String date, List<PillTaken> pillsTaken) {
@@ -181,8 +232,8 @@ class SharedPreferencesService {
         pillsTakenKey + date, PillTaken.encode(pillsTaken)));
   }
 
-  List<PillToTake> getPillsToTakeForDate(String currentDate) {
-    String? encodedPills = _sharedPreferences.getString(currentDate);
+  List<PillToTake> getPillsToTakeForDate(String date) {
+    String? encodedPills = _sharedPreferences.getString(pillsToTakeKey + date);
     if (encodedPills != null) {
       return PillToTake.decode(encodedPills);
     }
@@ -296,7 +347,8 @@ class SharedPreferencesService {
     for (String key in keys) {
       if (key == timeAppOpenedKey ||
           key == darkModeKey ||
-          key == migratedToYearlyKeysKey) {
+          key == migratedToYearlyKeysKey ||
+          key == migratedToPrefixedKeysKey) {
         continue;
       }
       unawaited(_sharedPreferences.remove(key));
@@ -320,8 +372,9 @@ class SharedPreferencesService {
     Set<String> keys = _sharedPreferences.getKeys();
     if (keys.isEmpty) return false;
     for (String key in keys) {
-      if (key.contains(RegExp('[0-9]')) && !key.contains(pillsTakenKey)) {
-        List<PillToTake> pills = getPillsToTakeForDate(key);
+      if (key.startsWith(pillsToTakeKey)) {
+        List<PillToTake> pills =
+            getPillsToTakeForDate(key.substring(pillsToTakeKey.length));
         if (pills.isNotEmpty) return true;
       }
     }

--- a/lib/service/shared_preferences_service.dart
+++ b/lib/service/shared_preferences_service.dart
@@ -203,38 +203,49 @@ class SharedPreferencesService {
       if (RegExp(r'^\d{4}/\d{1,2}/\d{1,2}$').hasMatch(key)) {
         final legacyValue = _sharedPreferences.getString(key);
         if (legacyValue != null) {
-          final targetKey = "$legacyToTakeKey$key";
-          final existingValue = _sharedPreferences.getString(targetKey);
+          try {
+            final targetKey = "$legacyToTakeKey$key";
+            final existingValue = _sharedPreferences.getString(targetKey);
 
-          String migratedValue;
-          if (existingValue != null) {
-            final legacyPills = PillToTake.decode(legacyValue)
-                .map((p) => p.copyWith(pillName: p.pillName.trim()))
-                .toList();
-            final existingPills = PillToTake.decode(existingValue)
-                .map((p) => p.copyWith(pillName: p.pillName.trim()))
-                .toList();
+            String migratedValue;
+            if (existingValue != null) {
+              final legacyPills = PillToTake.decode(legacyValue)
+                  .map((p) => p.copyWith(pillName: p.pillName.trim()))
+                  .toList();
+              final existingPills = PillToTake.decode(existingValue)
+                  .map((p) => p.copyWith(pillName: p.pillName.trim()))
+                  .toList();
 
-            final Map<String, PillToTake> mergedMap = {};
-            for (final pill in legacyPills) {
-              mergedMap[pill.pillName.toLowerCase()] = pill;
+              final Map<String, PillToTake> mergedMap = {};
+              for (final pill in legacyPills) {
+                mergedMap[pill.pillName.toLowerCase()] = pill;
+              }
+              for (final pill in existingPills) {
+                mergedMap[pill.pillName.toLowerCase()] = pill;
+              }
+              migratedValue = PillToTake.encode(mergedMap.values.toList());
+            } else {
+              migratedValue = legacyValue;
             }
-            for (final pill in existingPills) {
-              mergedMap[pill.pillName.toLowerCase()] = pill;
-            }
-            migratedValue = PillToTake.encode(mergedMap.values.toList());
-          } else {
-            migratedValue = legacyValue;
-          }
 
-          if (await _sharedPreferences.setString(targetKey, migratedValue)) {
-            if (!(await _sharedPreferences.remove(key))) {
-              log("Failed to remove non-prefixed key '$key' after migration to '$targetKey'",
-                  level: 1000);
+            if (await _sharedPreferences.setString(targetKey, migratedValue)) {
+              if (!(await _sharedPreferences.remove(key))) {
+                log(
+                    "Failed to remove non-prefixed key '$key' after migration to '$targetKey'",
+                    level: 1000);
+                allSucceeded = false;
+              }
+            } else {
+              log("Failed to write prefixed key '$targetKey'", level: 1000);
               allSucceeded = false;
             }
-          } else {
-            log("Failed to write prefixed key '$targetKey'", level: 1000);
+          } catch (e, s) {
+            log(
+              "Failed to migrate non-prefixed key '$key' to prefixed format",
+              error: e,
+              stackTrace: s,
+              level: 1000,
+            );
             allSucceeded = false;
           }
         }

--- a/lib/service/shared_preferences_service.dart
+++ b/lib/service/shared_preferences_service.dart
@@ -44,14 +44,7 @@ class SharedPreferencesService {
 
   Future<void> _migrateKeys({int? migrationYear}) async {
     await _migrateToYearlyKeys(migrationYear: migrationYear);
-    if (!(_sharedPreferences.getBool(migratedToYearlyKeysKey) ?? false)) {
-      return;
-    }
-
     await _migrateToPrefixedKeys();
-    if (!(_sharedPreferences.getBool(migratedToPrefixedKeysKey) ?? false)) {
-      return;
-    }
     await _migrateToDelimiterKeys();
   }
 
@@ -208,18 +201,7 @@ class SharedPreferencesService {
 
       // Identify keys that are YYYY/M/D (already migrated to yearly format but not yet prefixed)
       if (RegExp(r'^\d{4}/\d{1,2}/\d{1,2}$').hasMatch(key)) {
-        final legacyValue = _sharedPreferences.getString(key);
-        if (legacyValue != null) {
-          try {
-            final targetKey = "$legacyToTakeKey$key";
-            final existingValue = _sharedPreferences.getString(targetKey);
-
-            String migratedValue;
-            if (existingValue != null) {
-              final legacyPills = PillToTake.decode(legacyValue)
-      try {
-        // Identify keys that are YYYY/M/D (already migrated to yearly format but not yet prefixed)
-        if (RegExp(r'^\d{4}/\d{1,2}/\d{1,2}$').hasMatch(key)) {
+        try {
           final legacyValue = _sharedPreferences.getString(key);
           if (legacyValue != null) {
             final targetKey = "$legacyToTakeKey$key";
@@ -257,16 +239,11 @@ class SharedPreferencesService {
               allSucceeded = false;
             }
           }
+        } catch (e, st) {
+          log("Error migrating prefixed key '$key': $e",
+              level: 1000, stackTrace: st);
+          allSucceeded = false;
         }
-      } catch (e, stackTrace) {
-        final legacyValue = _sharedPreferences.getString(key);
-        log(
-          "Failed to migrate non-prefixed key '$key' with value '$legacyValue'",
-          error: e,
-          stackTrace: stackTrace,
-          level: 1000,
-        );
-        allSucceeded = false;
       }
     }
 
@@ -316,8 +293,9 @@ class SharedPreferencesService {
                 final existingPills = PillTaken.decode(existingValue)
                     .map((p) => p.copyWith(pillName: p.pillName.trim()))
                     .toList();
-                migratedValue = PillTaken.encode(
-                    {...legacyPills, ...existingPills}.toList());
+                // Combine and deduplicate exact matches
+                final merged = {...legacyPills, ...existingPills}.toList();
+                migratedValue = PillTaken.encode(merged);
               } else {
                 final legacyPills = PillToTake.decode(legacyValue)
                     .map((p) => p.copyWith(pillName: p.pillName.trim()))
@@ -341,8 +319,7 @@ class SharedPreferencesService {
 
             if (await _sharedPreferences.setString(targetKey, migratedValue)) {
               if (!(await _sharedPreferences.remove(key))) {
-                log(
-                    "Failed to remove old key '$key' after migration to '$targetKey'",
+                log("Failed to remove old key '$key' after migration to '$targetKey'",
                     level: 1000);
                 allSucceeded = false;
               }
@@ -351,13 +328,9 @@ class SharedPreferencesService {
               allSucceeded = false;
             }
           }
-        } catch (error, stackTrace) {
-          log(
-            "Failed to migrate key '$key' to '$targetKey'",
-            level: 1000,
-            error: error,
-            stackTrace: stackTrace,
-          );
+        } catch (e, st) {
+          log("Error migrating delimiter key '$key': $e",
+              level: 1000, stackTrace: st);
           allSucceeded = false;
         }
       }
@@ -371,10 +344,6 @@ class SharedPreferencesService {
     }
   }
 
-  // The Future returned by SharedPreferences write methods is intentionally
-  // unawaited: SharedPreferences commits writes to its in-memory cache
-  // synchronously before the Future resolves, so subsequent reads on the same
-  // instance always see the updated value immediately.
   void _setPillsForDate(String date, List<PillToTake> pills) {
     unawaited(_sharedPreferences.setString(
         pillsToTakePrefix + date, PillToTake.encode(pills)));
@@ -403,9 +372,6 @@ class SharedPreferencesService {
     return [];
   }
 
-  // void return: callers should read the specific date they need via
-  // getPillsToTakeForDate(date) after this call, since a pill scheduled
-  // across multiple days updates each date independently.
   void addPillToDates(DateTime startDate, PillToTake pill) {
     DateTime runningDate = startDate;
     int daysToTake = pill.amountOfDaysToTake;
@@ -428,8 +394,6 @@ class SharedPreferencesService {
     return pillsTaken;
   }
 
-  // Returns updated lists for currentDate so the BLoC can emit state without
-  // a second read. Returns null if the pill to update was not found.
   ({List<PillToTake> pillsToTake, List<PillTaken> pillsTaken})?
       updatePillForDate(PillToTake pillToTake, String currentDate) {
     List<PillToTake> pillsToTakeList = getPillsToTakeForDate(currentDate);
@@ -445,7 +409,6 @@ class SharedPreferencesService {
     final existingPill = pillsToTakeList[pillIndex];
     final pillToSave = pillToTake.copyWith(pillName: existingPill.pillName);
 
-    // Update taken list
     final updatedPillsTaken = addTakenPill(pillToSave, currentDate);
 
     if (pillToSave.pillRegiment == 0) {
@@ -460,7 +423,6 @@ class SharedPreferencesService {
     return (pillsToTake: pillsToTakeList, pillsTaken: updatedPillsTaken);
   }
 
-  // Returns the updated list for currentDate.
   List<PillToTake> removePillFromDate(
       PillToTake pillToTake, String currentDate) {
     List<PillToTake> pills = getPillsToTakeForDate(currentDate);

--- a/lib/service/shared_preferences_service.dart
+++ b/lib/service/shared_preferences_service.dart
@@ -45,12 +45,15 @@ class SharedPreferencesService {
   Future<void> _migrateKeys({int? migrationYear}) async {
     await _migrateToYearlyKeys(migrationYear: migrationYear);
     await _migrateToPrefixedKeys();
+    await _migrateToDelimiterKeys();
   }
 
   Future<void> _migrateToYearlyKeys({int? migrationYear}) async {
     if (_sharedPreferences.getBool(migratedToYearlyKeysKey) ?? false) {
       return;
     }
+
+    const String legacyTakenKey = "pillsTaken";
 
     final keys = _sharedPreferences.getKeys().toList();
     final currentYear = migrationYear ?? _dateService.now().year;
@@ -60,7 +63,8 @@ class SharedPreferencesService {
       if (key == timeAppOpenedKey ||
           key == darkModeKey ||
           key == migratedToYearlyKeysKey ||
-          key == migratedToPrefixedKeysKey) {
+          key == migratedToPrefixedKeysKey ||
+          key == migratedToDelimiterKeysKey) {
         continue;
       }
 
@@ -68,8 +72,8 @@ class SharedPreferencesService {
       if (legacyValue == null) continue;
 
       try {
-        if (key.startsWith(pillsTakenKey)) {
-          final datePart = key.substring(pillsTakenKey.length);
+        if (key.startsWith(legacyTakenKey)) {
+          final datePart = key.substring(legacyTakenKey.length);
           // Match "M/D" or "MM/DD" but NOT "YYYY/M/D"
           if (RegExp(r'^\d{1,2}/\d{1,2}$').hasMatch(datePart)) {
             final legacyPills = PillTaken.decode(legacyValue);
@@ -85,7 +89,7 @@ class SharedPreferencesService {
             for (final entry in pillsByYear.entries) {
               final year = entry.key;
               final pillsForYear = entry.value;
-              final targetKey = "$pillsTakenKey$year/$datePart";
+              final targetKey = "$legacyTakenKey$year/$datePart";
               final existingYearlyValue =
                   _sharedPreferences.getString(targetKey);
 
@@ -178,6 +182,9 @@ class SharedPreferencesService {
       return;
     }
 
+    const String legacyTakenKey = "pillsTaken";
+    const String legacyToTakeKey = "pillsToTake";
+
     final keys = _sharedPreferences.getKeys().toList();
     bool allSucceeded = true;
 
@@ -186,17 +193,41 @@ class SharedPreferencesService {
           key == darkModeKey ||
           key == migratedToYearlyKeysKey ||
           key == migratedToPrefixedKeysKey ||
-          key.startsWith(pillsTakenKey) ||
-          key.startsWith(pillsToTakeKey)) {
+          key == migratedToDelimiterKeysKey ||
+          key.startsWith(legacyTakenKey) ||
+          key.startsWith(legacyToTakeKey)) {
         continue;
       }
 
       // Identify keys that are YYYY/M/D (already migrated to yearly format but not yet prefixed)
       if (RegExp(r'^\d{4}/\d{1,2}/\d{1,2}$').hasMatch(key)) {
-        final value = _sharedPreferences.getString(key);
-        if (value != null) {
-          final targetKey = "$pillsToTakeKey$key";
-          if (await _sharedPreferences.setString(targetKey, value)) {
+        final legacyValue = _sharedPreferences.getString(key);
+        if (legacyValue != null) {
+          final targetKey = "$legacyToTakeKey$key";
+          final existingValue = _sharedPreferences.getString(targetKey);
+
+          String migratedValue;
+          if (existingValue != null) {
+            final legacyPills = PillToTake.decode(legacyValue)
+                .map((p) => p.copyWith(pillName: p.pillName.trim()))
+                .toList();
+            final existingPills = PillToTake.decode(existingValue)
+                .map((p) => p.copyWith(pillName: p.pillName.trim()))
+                .toList();
+
+            final Map<String, PillToTake> mergedMap = {};
+            for (final pill in legacyPills) {
+              mergedMap[pill.pillName.toLowerCase()] = pill;
+            }
+            for (final pill in existingPills) {
+              mergedMap[pill.pillName.toLowerCase()] = pill;
+            }
+            migratedValue = PillToTake.encode(mergedMap.values.toList());
+          } else {
+            migratedValue = legacyValue;
+          }
+
+          if (await _sharedPreferences.setString(targetKey, migratedValue)) {
             if (!(await _sharedPreferences.remove(key))) {
               log("Failed to remove non-prefixed key '$key' after migration to '$targetKey'",
                   level: 1000);
@@ -218,22 +249,105 @@ class SharedPreferencesService {
     }
   }
 
+  Future<void> _migrateToDelimiterKeys() async {
+    if (_sharedPreferences.getBool(migratedToDelimiterKeysKey) ?? false) {
+      return;
+    }
+
+    const String legacyTakenKey = "pillsTaken";
+    const String legacyToTakeKey = "pillsToTake";
+
+    final keys = _sharedPreferences.getKeys().toList();
+    bool allSucceeded = true;
+
+    for (String key in keys) {
+      String? targetKey;
+      bool isTaken = false;
+      if (key.startsWith(legacyTakenKey) && !key.startsWith(pillsTakenPrefix)) {
+        targetKey = "$pillsTakenPrefix${key.substring(legacyTakenKey.length)}";
+        isTaken = true;
+      } else if (key.startsWith(legacyToTakeKey) &&
+          !key.startsWith(pillsToTakePrefix)) {
+        targetKey = "$pillsToTakePrefix${key.substring(legacyToTakeKey.length)}";
+        isTaken = false;
+      }
+
+      if (targetKey != null) {
+        final legacyValue = _sharedPreferences.getString(key);
+        if (legacyValue != null) {
+          final existingValue = _sharedPreferences.getString(targetKey);
+
+          String migratedValue;
+          if (existingValue != null) {
+            if (isTaken) {
+              final legacyPills = PillTaken.decode(legacyValue)
+                  .map((p) => p.copyWith(pillName: p.pillName.trim()))
+                  .toList();
+              final existingPills = PillTaken.decode(existingValue)
+                  .map((p) => p.copyWith(pillName: p.pillName.trim()))
+                  .toList();
+              migratedValue =
+                  PillTaken.encode({...legacyPills, ...existingPills}.toList());
+            } else {
+              final legacyPills = PillToTake.decode(legacyValue)
+                  .map((p) => p.copyWith(pillName: p.pillName.trim()))
+                  .toList();
+              final existingPills = PillToTake.decode(existingValue)
+                  .map((p) => p.copyWith(pillName: p.pillName.trim()))
+                  .toList();
+
+              final Map<String, PillToTake> mergedMap = {};
+              for (final pill in legacyPills) {
+                mergedMap[pill.pillName.toLowerCase()] = pill;
+              }
+              for (final pill in existingPills) {
+                mergedMap[pill.pillName.toLowerCase()] = pill;
+              }
+              migratedValue = PillToTake.encode(mergedMap.values.toList());
+            }
+          } else {
+            migratedValue = legacyValue;
+          }
+
+          if (await _sharedPreferences.setString(targetKey, migratedValue)) {
+            if (!(await _sharedPreferences.remove(key))) {
+              log("Failed to remove old key '$key' after migration to '$targetKey'",
+                  level: 1000);
+              allSucceeded = false;
+            }
+          } else {
+            log("Failed to write delimiter key '$targetKey'", level: 1000);
+            allSucceeded = false;
+          }
+        }
+      }
+    }
+
+    if (allSucceeded) {
+      if (!(await _sharedPreferences.setBool(migratedToDelimiterKeysKey, true))) {
+        log("Failed to set migration completion flag '$migratedToDelimiterKeysKey'",
+            level: 1000);
+      }
+    }
+  }
+
   // The Future returned by SharedPreferences write methods is intentionally
   // unawaited: SharedPreferences commits writes to its in-memory cache
   // synchronously before the Future resolves, so subsequent reads on the same
   // instance always see the updated value immediately.
   void _setPillsForDate(String date, List<PillToTake> pills) {
     unawaited(_sharedPreferences.setString(
-        pillsToTakeKey + date, PillToTake.encode(pills)));
+        pillsToTakePrefix + date, PillToTake.encode(pills)));
   }
 
   void _setPillsTakenForDate(String date, List<PillTaken> pillsTaken) {
     unawaited(_sharedPreferences.setString(
-        pillsTakenKey + date, PillTaken.encode(pillsTaken)));
+        pillsTakenPrefix + date, PillTaken.encode(pillsTaken)));
   }
 
   List<PillToTake> getPillsToTakeForDate(String date) {
-    String? encodedPills = _sharedPreferences.getString(pillsToTakeKey + date);
+    String? encodedPills =
+        _sharedPreferences.getString(pillsToTakePrefix + date);
     if (encodedPills != null) {
       return PillToTake.decode(encodedPills);
     }
@@ -241,7 +355,8 @@ class SharedPreferencesService {
   }
 
   List<PillTaken> getPillsTakenForDate(String date) {
-    String? encodedPills = _sharedPreferences.getString(pillsTakenKey + date);
+    String? encodedPills =
+        _sharedPreferences.getString(pillsTakenPrefix + date);
     if (encodedPills != null) {
       return PillTaken.decode(encodedPills);
     }
@@ -348,7 +463,8 @@ class SharedPreferencesService {
       if (key == timeAppOpenedKey ||
           key == darkModeKey ||
           key == migratedToYearlyKeysKey ||
-          key == migratedToPrefixedKeysKey) {
+          key == migratedToPrefixedKeysKey ||
+          key == migratedToDelimiterKeysKey) {
         continue;
       }
       unawaited(_sharedPreferences.remove(key));
@@ -372,9 +488,9 @@ class SharedPreferencesService {
     Set<String> keys = _sharedPreferences.getKeys();
     if (keys.isEmpty) return false;
     for (String key in keys) {
-      if (key.startsWith(pillsToTakeKey)) {
+      if (key.startsWith(pillsToTakePrefix)) {
         List<PillToTake> pills =
-            getPillsToTakeForDate(key.substring(pillsToTakeKey.length));
+            getPillsToTakeForDate(key.substring(pillsToTakePrefix.length));
         if (pills.isNotEmpty) return true;
       }
     }

--- a/lib/service/shared_preferences_service.dart
+++ b/lib/service/shared_preferences_service.dart
@@ -44,7 +44,14 @@ class SharedPreferencesService {
 
   Future<void> _migrateKeys({int? migrationYear}) async {
     await _migrateToYearlyKeys(migrationYear: migrationYear);
+    if (!(_sharedPreferences.getBool(migratedToYearlyKeysKey) ?? false)) {
+      return;
+    }
+
     await _migrateToPrefixedKeys();
+    if (!(_sharedPreferences.getBool(migratedToPrefixedKeysKey) ?? false)) {
+      return;
+    }
     await _migrateToDelimiterKeys();
   }
 

--- a/lib/service/shared_preferences_service.dart
+++ b/lib/service/shared_preferences_service.dart
@@ -284,52 +284,63 @@ class SharedPreferencesService {
       }
 
       if (targetKey != null) {
-        final legacyValue = _sharedPreferences.getString(key);
-        if (legacyValue != null) {
-          final existingValue = _sharedPreferences.getString(targetKey);
+        try {
+          final legacyValue = _sharedPreferences.getString(key);
+          if (legacyValue != null) {
+            final existingValue = _sharedPreferences.getString(targetKey);
 
-          String migratedValue;
-          if (existingValue != null) {
-            if (isTaken) {
-              final legacyPills = PillTaken.decode(legacyValue)
-                  .map((p) => p.copyWith(pillName: p.pillName.trim()))
-                  .toList();
-              final existingPills = PillTaken.decode(existingValue)
-                  .map((p) => p.copyWith(pillName: p.pillName.trim()))
-                  .toList();
-              migratedValue =
-                  PillTaken.encode({...legacyPills, ...existingPills}.toList());
+            String migratedValue;
+            if (existingValue != null) {
+              if (isTaken) {
+                final legacyPills = PillTaken.decode(legacyValue)
+                    .map((p) => p.copyWith(pillName: p.pillName.trim()))
+                    .toList();
+                final existingPills = PillTaken.decode(existingValue)
+                    .map((p) => p.copyWith(pillName: p.pillName.trim()))
+                    .toList();
+                migratedValue = PillTaken.encode(
+                    {...legacyPills, ...existingPills}.toList());
+              } else {
+                final legacyPills = PillToTake.decode(legacyValue)
+                    .map((p) => p.copyWith(pillName: p.pillName.trim()))
+                    .toList();
+                final existingPills = PillToTake.decode(existingValue)
+                    .map((p) => p.copyWith(pillName: p.pillName.trim()))
+                    .toList();
+
+                final Map<String, PillToTake> mergedMap = {};
+                for (final pill in legacyPills) {
+                  mergedMap[pill.pillName.toLowerCase()] = pill;
+                }
+                for (final pill in existingPills) {
+                  mergedMap[pill.pillName.toLowerCase()] = pill;
+                }
+                migratedValue = PillToTake.encode(mergedMap.values.toList());
+              }
             } else {
-              final legacyPills = PillToTake.decode(legacyValue)
-                  .map((p) => p.copyWith(pillName: p.pillName.trim()))
-                  .toList();
-              final existingPills = PillToTake.decode(existingValue)
-                  .map((p) => p.copyWith(pillName: p.pillName.trim()))
-                  .toList();
-
-              final Map<String, PillToTake> mergedMap = {};
-              for (final pill in legacyPills) {
-                mergedMap[pill.pillName.toLowerCase()] = pill;
-              }
-              for (final pill in existingPills) {
-                mergedMap[pill.pillName.toLowerCase()] = pill;
-              }
-              migratedValue = PillToTake.encode(mergedMap.values.toList());
+              migratedValue = legacyValue;
             }
-          } else {
-            migratedValue = legacyValue;
-          }
 
-          if (await _sharedPreferences.setString(targetKey, migratedValue)) {
-            if (!(await _sharedPreferences.remove(key))) {
-              log("Failed to remove old key '$key' after migration to '$targetKey'",
-                  level: 1000);
+            if (await _sharedPreferences.setString(targetKey, migratedValue)) {
+              if (!(await _sharedPreferences.remove(key))) {
+                log(
+                    "Failed to remove old key '$key' after migration to '$targetKey'",
+                    level: 1000);
+                allSucceeded = false;
+              }
+            } else {
+              log("Failed to write delimiter key '$targetKey'", level: 1000);
               allSucceeded = false;
             }
-          } else {
-            log("Failed to write delimiter key '$targetKey'", level: 1000);
-            allSucceeded = false;
           }
+        } catch (error, stackTrace) {
+          log(
+            "Failed to migrate key '$key' to '$targetKey'",
+            level: 1000,
+            error: error,
+            stackTrace: stackTrace,
+          );
+          allSucceeded = false;
         }
       }
     }

--- a/lib/service/shared_preferences_service.dart
+++ b/lib/service/shared_preferences_service.dart
@@ -256,6 +256,15 @@ class SharedPreferencesService {
   }
 
   Future<void> _migrateToDelimiterKeys() async {
+    final migratedToYearly =
+        _sharedPreferences.getBool(migratedToYearlyKeysKey) ?? false;
+    final migratedToPrefixed =
+        _sharedPreferences.getBool(migratedToPrefixedKeysKey) ?? false;
+
+    if (!migratedToYearly || !migratedToPrefixed) {
+      return;
+    }
+
     if (_sharedPreferences.getBool(migratedToDelimiterKeysKey) ?? false) {
       return;
     }
@@ -269,11 +278,12 @@ class SharedPreferencesService {
     for (String key in keys) {
       String? targetKey;
       bool isTaken = false;
-      if (key.startsWith(legacyTakenKey) && !key.startsWith(pillsTakenPrefix)) {
+
+      // Restrict migration to expected pre-delimiter yearly shapes
+      if (RegExp(r'^pillsTaken\d{4}/\d{1,2}/\d{1,2}$').hasMatch(key)) {
         targetKey = "$pillsTakenPrefix${key.substring(legacyTakenKey.length)}";
         isTaken = true;
-      } else if (key.startsWith(legacyToTakeKey) &&
-          !key.startsWith(pillsToTakePrefix)) {
+      } else if (RegExp(r'^pillsToTake\d{4}/\d{1,2}/\d{1,2}$').hasMatch(key)) {
         targetKey = "$pillsToTakePrefix${key.substring(legacyToTakeKey.length)}";
         isTaken = false;
       }

--- a/test/shared_preferences_test.dart
+++ b/test/shared_preferences_test.dart
@@ -185,7 +185,7 @@ void main() {
   });
 
   group("SharedPreferences Service migration", () {
-    test("Full migration (Yearly + Prefixed)", () async {
+    test("Full migration (Yearly + Prefixed + Delimiter)", () async {
       const pill = PillToTake(
           pillName: "Test Pill", pillRegiment: 1, amountOfDaysToTake: 1);
       final pillTaken = PillTaken(
@@ -206,6 +206,7 @@ void main() {
         "some_other_key": otherValue,
         migratedToYearlyKeysKey: false,
         migratedToPrefixedKeysKey: false,
+        migratedToDelimiterKeysKey: false,
       });
 
       // Create a new service instance to trigger migration with a fixed year
@@ -214,15 +215,17 @@ void main() {
 
       SharedPreferences prefs = await SharedPreferences.getInstance();
 
-      // Verify values were migrated correctly to PREFIXED yearly keys
-      expect(prefs.getString("$pillsToTakeKey$migrationYear/3/29"), migratedPillsValue);
-      expect(prefs.getString("$pillsTakenKey$migrationYear/3/29"),
+      // Verify values were migrated correctly to PREFIXED yearly keys WITH delimiter
+      expect(prefs.getString("$pillsToTakePrefix$migrationYear/3/29"), migratedPillsValue);
+      expect(prefs.getString("$pillsTakenPrefix$migrationYear/3/29"),
           migratedTakenValue);
 
       // Verify old keys were removed
       expect(prefs.containsKey("3/29"), false);
       expect(prefs.containsKey("pillsTaken3/29"), false);
-      expect(prefs.containsKey("$migrationYear/3/29"), false); // Intermediate yearly key should be gone
+      expect(prefs.containsKey("$migrationYear/3/29"), false);
+      expect(prefs.containsKey("pillsToTake$migrationYear/3/29"), false);
+      expect(prefs.containsKey("pillsTaken$migrationYear/3/29"), false);
 
       // Verify unrelated keys were preserved
       expect(prefs.getString("some_other_key"), otherValue);
@@ -230,25 +233,27 @@ void main() {
       // Verify migration flags were set
       expect(prefs.getBool(migratedToYearlyKeysKey), true);
       expect(prefs.getBool(migratedToPrefixedKeysKey), true);
+      expect(prefs.getBool(migratedToDelimiterKeysKey), true);
     });
 
-    test("Migration from Yearly to Prefixed only", () async {
+    test("Migration from Prefixed to Delimiter only", () async {
       const pill = PillToTake(
           pillName: "Test Pill", pillRegiment: 1, amountOfDaysToTake: 1);
       final String pillsValue = PillToTake.encode([pill]);
 
       SharedPreferences.setMockInitialValues({
-        "2024/1/1": pillsValue,
+        "pillsToTake2024/1/1": pillsValue,
         migratedToYearlyKeysKey: true,
-        migratedToPrefixedKeysKey: false,
+        migratedToPrefixedKeysKey: true,
+        migratedToDelimiterKeysKey: false,
       });
 
       await SharedPreferencesService.create(dateService);
 
       final prefs = await SharedPreferences.getInstance();
-      expect(prefs.getString("${pillsToTakeKey}2024/1/1"), pillsValue);
-      expect(prefs.containsKey("2024/1/1"), false);
-      expect(prefs.getBool(migratedToPrefixedKeysKey), true);
+      expect(prefs.getString("${pillsToTakePrefix}2024/1/1"), pillsValue);
+      expect(prefs.containsKey("pillsToTake2024/1/1"), false);
+      expect(prefs.getBool(migratedToDelimiterKeysKey), true);
     });
 
     test("Migration with conflict resolution (merge data)", () async {
@@ -274,6 +279,7 @@ void main() {
         "pillsTaken2026/3/29": PillTaken.encode([pillTaken2.copyWith(pillName: "Pill B")]),
         migratedToYearlyKeysKey: false,
         migratedToPrefixedKeysKey: false,
+        migratedToDelimiterKeysKey: false,
       });
 
       await SharedPreferencesService.createForTesting(dateService,
@@ -282,9 +288,9 @@ void main() {
       final prefs = await SharedPreferences.getInstance();
 
       final migratedPills =
-          PillToTake.decode(prefs.getString("${pillsToTakeKey}2026/3/29") ?? "");
+          PillToTake.decode(prefs.getString("${pillsToTakePrefix}2026/3/29") ?? "");
       final migratedTaken =
-          PillTaken.decode(prefs.getString("${pillsTakenKey}2026/3/29") ?? "");
+          PillTaken.decode(prefs.getString("${pillsTakenPrefix}2026/3/29") ?? "");
 
       expect(migratedPills.length, 2);
       expect(migratedPills.any((p) => p.pillName == "Pill A"), true);

--- a/test/shared_preferences_test.dart
+++ b/test/shared_preferences_test.dart
@@ -185,7 +185,7 @@ void main() {
   });
 
   group("SharedPreferences Service migration", () {
-    test("Standard migration", () async {
+    test("Full migration (Yearly + Prefixed)", () async {
       const pill = PillToTake(
           pillName: "Test Pill", pillRegiment: 1, amountOfDaysToTake: 1);
       final pillTaken = PillTaken(
@@ -205,6 +205,7 @@ void main() {
         "pillsTaken3/29": pillsTakenValue,
         "some_other_key": otherValue,
         migratedToYearlyKeysKey: false,
+        migratedToPrefixedKeysKey: false,
       });
 
       // Create a new service instance to trigger migration with a fixed year
@@ -213,20 +214,41 @@ void main() {
 
       SharedPreferences prefs = await SharedPreferences.getInstance();
 
-      // Verify values were migrated correctly
-      expect(prefs.getString("$migrationYear/3/29"), migratedPillsValue);
+      // Verify values were migrated correctly to PREFIXED yearly keys
+      expect(prefs.getString("$pillsToTakeKey$migrationYear/3/29"), migratedPillsValue);
       expect(prefs.getString("$pillsTakenKey$migrationYear/3/29"),
           migratedTakenValue);
 
       // Verify old keys were removed
       expect(prefs.containsKey("3/29"), false);
       expect(prefs.containsKey("pillsTaken3/29"), false);
+      expect(prefs.containsKey("$migrationYear/3/29"), false); // Intermediate yearly key should be gone
 
       // Verify unrelated keys were preserved
       expect(prefs.getString("some_other_key"), otherValue);
 
-      // Verify migration flag was set
+      // Verify migration flags were set
       expect(prefs.getBool(migratedToYearlyKeysKey), true);
+      expect(prefs.getBool(migratedToPrefixedKeysKey), true);
+    });
+
+    test("Migration from Yearly to Prefixed only", () async {
+      const pill = PillToTake(
+          pillName: "Test Pill", pillRegiment: 1, amountOfDaysToTake: 1);
+      final String pillsValue = PillToTake.encode([pill]);
+
+      SharedPreferences.setMockInitialValues({
+        "2024/1/1": pillsValue,
+        migratedToYearlyKeysKey: true,
+        migratedToPrefixedKeysKey: false,
+      });
+
+      await SharedPreferencesService.create(dateService);
+
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getString("${pillsToTakeKey}2024/1/1"), pillsValue);
+      expect(prefs.containsKey("2024/1/1"), false);
+      expect(prefs.getBool(migratedToPrefixedKeysKey), true);
     });
 
     test("Migration with conflict resolution (merge data)", () async {
@@ -251,6 +273,7 @@ void main() {
         "2026/3/29": PillToTake.encode([pill2.copyWith(pillName: "Pill B")]),
         "pillsTaken2026/3/29": PillTaken.encode([pillTaken2.copyWith(pillName: "Pill B")]),
         migratedToYearlyKeysKey: false,
+        migratedToPrefixedKeysKey: false,
       });
 
       await SharedPreferencesService.createForTesting(dateService,
@@ -259,9 +282,9 @@ void main() {
       final prefs = await SharedPreferences.getInstance();
 
       final migratedPills =
-          PillToTake.decode(prefs.getString("2026/3/29") ?? "");
+          PillToTake.decode(prefs.getString("${pillsToTakeKey}2026/3/29") ?? "");
       final migratedTaken =
-          PillTaken.decode(prefs.getString("pillsTaken2026/3/29") ?? "");
+          PillTaken.decode(prefs.getString("${pillsTakenKey}2026/3/29") ?? "");
 
       expect(migratedPills.length, 2);
       expect(migratedPills.any((p) => p.pillName == "Pill A"), true);


### PR DESCRIPTION
Fixes #79 

This pull request implements a multi-stage migration for SharedPreferences keys related to pill tracking, ensuring data consistency and forward compatibility. It introduces new key prefixes and migration flags, updates all relevant code to use the new key formats, and expands the test suite to cover all migration scenarios, including conflict resolution and partial migrations.

**Migration and Key Format Updates:**

* Added three migration steps to `SharedPreferencesService`:
  - `_migrateToYearlyKeys`: Migrates old keys to a yearly format.
  - `_migrateToPrefixedKeys`: Adds a prefix (`pillsToTake` or `pillsTaken`) to yearly keys.
  - [`_migrateToDelimiterKeys`](diffhunk://#diff-9a108456bfa412005b2ee5c1b691b9582e0cc50a43edc71dcae1aba68d9063e6R46-R76): Adds an underscore delimiter to prefixed keys for final format.
* Introduced new constants for key prefixes and migration flags in `lib/constants.dart`: `pillsTakenPrefix`, `pillsToTakePrefix`, `migratedToPrefixedKeysKey`, and `migratedToDelimiterKeysKey`.
* Updated all read/write operations in `SharedPreferencesService` to use the new prefixed key format, ensuring consistent access to pill data. 

**Testing Enhancements:**

* Expanded migration tests in `test/shared_preferences_test.dart`:
  - Renamed and extended the main migration test to cover all three migration steps and verify correct key removal and flag setting.
  - Added a test for running only the delimiter migration step.
  - Ensured tests check for proper conflict resolution and merging of pill data during migration.

These changes ensure that all pill-related data is stored under a consistent, future-proof key format and that migrations are robustly tested for all edge cases.