### PR TITLE
_mainPageTabBarView and _mainPageAppBar are free functions taking BuildContext — anti-pattern

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -51,7 +51,6 @@ class MyApp extends StatelessWidget {
           darkTheme: ThemeData.dark(),
           themeMode: state,
           home: MainPage(
-              title: appTitle,
               sharedPreferencesService: sharedPreferencesService,
               dateService: dateService),
         );

--- a/lib/page/main_page.dart
+++ b/lib/page/main_page.dart
@@ -109,7 +109,7 @@ class _MainPageState extends State<MainPage> with WidgetsBindingObserver {
               now: _now,
               dateService: widget.dateService,
               sharedPreferencesService: widget.sharedPreferencesService,
-              onAddPillTapped: (now) => _updateNow(now),
+              onAddPillTapped: (updatedNow) => _updateNow(updatedNow),
             )));
   }
 }

--- a/lib/page/main_page.dart
+++ b/lib/page/main_page.dart
@@ -90,9 +90,9 @@ class _MainPageState extends State<MainPage> with WidgetsBindingObserver {
         date: todayStr));
   }
 
-  void _updateNow() {
+  void _updateNow([DateTime? now]) {
     setState(() {
-      _now = widget.dateService.now();
+      _now = now ?? widget.dateService.now();
     });
   }
 
@@ -103,67 +103,69 @@ class _MainPageState extends State<MainPage> with WidgetsBindingObserver {
         child: Scaffold(
             appBar: _MainPageAppBar(
               key: const ValueKey('MainPageAppBar'),
+              title: widget.title,
               onPillsTabTapped: _loadPillsForToday,
-              onSettingsTabTapped: _updateNow,
+              onSettingsTabTapped: () => _updateNow(),
             ),
             body: _MainPageTabBarView(
               key: const ValueKey('MainPageTabBarView'),
               now: _now,
               dateService: widget.dateService,
               sharedPreferencesService: widget.sharedPreferencesService,
-              onAddPillTapped: _updateNow,
+              onAddPillTapped: (now) => _updateNow(now),
             )));
   }
 }
 
 class _MainPageAppBar extends StatelessWidget implements PreferredSizeWidget {
+  final String title;
   final VoidCallback onPillsTabTapped;
   final VoidCallback onSettingsTabTapped;
 
   const _MainPageAppBar({
     super.key,
+    required this.title,
     required this.onPillsTabTapped,
     required this.onSettingsTabTapped,
   });
 
   @override
   Widget build(BuildContext context) {
-    return PreferredSize(
-      preferredSize: const Size.fromHeight(50),
-      child: AppBar(
-        bottom: TabBar(
-          tabs: const [
-            Tab(icon: Icon(CustomIcons.pill)),
-            Tab(icon: Icon(Icons.watch_later_rounded)),
-            Tab(icon: Icon(Icons.settings)),
-          ],
-          onTap: (tabIndex) {
-            switch (tabIndex) {
-              case pillsToTakeTabIndex:
-              case pillsTakenTabIndex:
-                onPillsTabTapped();
-                break;
-              case settingsTabIndex:
-                onSettingsTabTapped();
-                context
-                    .read<ClearPillsBloc>()
-                    .add(ClearPillsEvent.updatePillsStatus);
-            }
-          },
-        ),
+    return AppBar(
+      title: Text(title),
+      bottom: TabBar(
+        tabs: const [
+          Tab(icon: Icon(CustomIcons.pill)),
+          Tab(icon: Icon(Icons.watch_later_rounded)),
+          Tab(icon: Icon(Icons.settings)),
+        ],
+        onTap: (tabIndex) {
+          switch (tabIndex) {
+            case pillsToTakeTabIndex:
+            case pillsTakenTabIndex:
+              onPillsTabTapped();
+              break;
+            case settingsTabIndex:
+              onSettingsTabTapped();
+              context
+                  .read<ClearPillsBloc>()
+                  .add(ClearPillsEvent.updatePillsStatus);
+          }
+        },
       ),
     );
   }
 
   @override
-  Size get preferredSize => const Size.fromHeight(50);
+  Size get preferredSize =>
+      const Size.fromHeight(kToolbarHeight + kTextTabBarHeight);
 }
 
 class _MainPageTabBarView extends StatelessWidget {
   final DateTime now;
   final DateService dateService;
   final SharedPreferencesService sharedPreferencesService;
-  final VoidCallback onAddPillTapped;
+  final ValueChanged<DateTime> onAddPillTapped;
 
   const _MainPageTabBarView({
     super.key,
@@ -189,8 +191,8 @@ class _MainPageTabBarView extends StatelessWidget {
               padding: const EdgeInsets.all(10.0),
               child: FloatingActionButton(
                   onPressed: () {
-                    onAddPillTapped();
                     final updatedNow = dateService.now();
+                    onAddPillTapped(updatedNow);
                     showModalBottomSheet(
                         context: context,
                         isScrollControlled: true,

--- a/lib/page/main_page.dart
+++ b/lib/page/main_page.dart
@@ -102,10 +102,12 @@ class _MainPageState extends State<MainPage> with WidgetsBindingObserver {
         length: amountOfTabs,
         child: Scaffold(
             appBar: _MainPageAppBar(
+              key: const ValueKey('MainPageAppBar'),
               onPillsTabTapped: _loadPillsForToday,
               onSettingsTabTapped: _updateNow,
             ),
             body: _MainPageTabBarView(
+              key: const ValueKey('MainPageTabBarView'),
               now: _now,
               dateService: widget.dateService,
               sharedPreferencesService: widget.sharedPreferencesService,
@@ -119,6 +121,7 @@ class _MainPageAppBar extends StatelessWidget implements PreferredSizeWidget {
   final VoidCallback onSettingsTabTapped;
 
   const _MainPageAppBar({
+    super.key,
     required this.onPillsTabTapped,
     required this.onSettingsTabTapped,
   });
@@ -163,6 +166,7 @@ class _MainPageTabBarView extends StatelessWidget {
   final VoidCallback onAddPillTapped;
 
   const _MainPageTabBarView({
+    super.key,
     required this.now,
     required this.dateService,
     required this.sharedPreferencesService,
@@ -186,6 +190,7 @@ class _MainPageTabBarView extends StatelessWidget {
               child: FloatingActionButton(
                   onPressed: () {
                     onAddPillTapped();
+                    final updatedNow = dateService.now();
                     showModalBottomSheet(
                         context: context,
                         isScrollControlled: true,
@@ -194,7 +199,7 @@ class _MainPageTabBarView extends StatelessWidget {
                               BorderRadius.vertical(top: Radius.circular(20)),
                         ),
                         builder: (context) => AddingPillForm(
-                            pillDate: now,
+                            pillDate: updatedNow,
                             sharedPreferencesService:
                                 sharedPreferencesService,
                             dateService: dateService));

--- a/lib/page/main_page.dart
+++ b/lib/page/main_page.dart
@@ -18,11 +18,9 @@ const int settingsTabIndex = 2;
 class MainPage extends StatefulWidget {
   const MainPage(
       {super.key,
-      required this.title,
       required this.sharedPreferencesService,
       required this.dateService});
 
-  final String title;
   final SharedPreferencesService sharedPreferencesService;
   final DateService dateService;
 
@@ -103,7 +101,6 @@ class _MainPageState extends State<MainPage> with WidgetsBindingObserver {
         child: Scaffold(
             appBar: _MainPageAppBar(
               key: const ValueKey('MainPageAppBar'),
-              title: widget.title,
               onPillsTabTapped: _loadPillsForToday,
               onSettingsTabTapped: () => _updateNow(),
             ),
@@ -118,13 +115,11 @@ class _MainPageState extends State<MainPage> with WidgetsBindingObserver {
 }
 
 class _MainPageAppBar extends StatelessWidget implements PreferredSizeWidget {
-  final String title;
   final VoidCallback onPillsTabTapped;
   final VoidCallback onSettingsTabTapped;
 
   const _MainPageAppBar({
     super.key,
-    required this.title,
     required this.onPillsTabTapped,
     required this.onSettingsTabTapped,
   });
@@ -158,7 +153,7 @@ class _MainPageAppBar extends StatelessWidget implements PreferredSizeWidget {
   }
 
   @override
-  Size get preferredSize => const Size.fromHeight(50.0);
+  Size get preferredSize => const Size.fromHeight(kTabLabelHeight);
 }
 
 class _MainPageTabBarView extends StatelessWidget {

--- a/lib/page/main_page.dart
+++ b/lib/page/main_page.dart
@@ -153,7 +153,7 @@ class _MainPageAppBar extends StatelessWidget implements PreferredSizeWidget {
   }
 
   @override
-  Size get preferredSize => const Size.fromHeight(kTabLabelHeight);
+  Size get preferredSize => const Size.fromHeight(kTextTabBarHeight);
 }
 
 class _MainPageTabBarView extends StatelessWidget {

--- a/lib/page/main_page.dart
+++ b/lib/page/main_page.dart
@@ -132,7 +132,7 @@ class _MainPageAppBar extends StatelessWidget implements PreferredSizeWidget {
   @override
   Widget build(BuildContext context) {
     return AppBar(
-      title: Text(title),
+      toolbarHeight: 0,
       bottom: TabBar(
         tabs: const [
           Tab(icon: Icon(CustomIcons.pill)),
@@ -158,8 +158,7 @@ class _MainPageAppBar extends StatelessWidget implements PreferredSizeWidget {
   }
 
   @override
-  Size get preferredSize =>
-      const Size.fromHeight(kToolbarHeight + kTextTabBarHeight);
+  Size get preferredSize => const Size.fromHeight(50.0);
 }
 
 class _MainPageTabBarView extends StatelessWidget {

--- a/lib/page/main_page.dart
+++ b/lib/page/main_page.dart
@@ -150,6 +150,7 @@ class _MainPageAppBar extends StatelessWidget implements PreferredSizeWidget {
               context
                   .read<ClearPillsBloc>()
                   .add(ClearPillsEvent.updatePillsStatus);
+              break;
           }
         },
       ),

--- a/lib/page/main_page.dart
+++ b/lib/page/main_page.dart
@@ -101,11 +101,30 @@ class _MainPageState extends State<MainPage> with WidgetsBindingObserver {
     return DefaultTabController(
         length: amountOfTabs,
         child: Scaffold(
-            appBar: _mainPageAppBar(context),
-            body: _mainPageTabBarView()));
+            appBar: _MainPageAppBar(
+              onPillsTabTapped: _loadPillsForToday,
+              onSettingsTabTapped: _updateNow,
+            ),
+            body: _MainPageTabBarView(
+              now: _now,
+              dateService: widget.dateService,
+              sharedPreferencesService: widget.sharedPreferencesService,
+              onAddPillTapped: _updateNow,
+            )));
   }
+}
 
-  PreferredSizeWidget _mainPageAppBar(BuildContext context) {
+class _MainPageAppBar extends StatelessWidget implements PreferredSizeWidget {
+  final VoidCallback onPillsTabTapped;
+  final VoidCallback onSettingsTabTapped;
+
+  const _MainPageAppBar({
+    required this.onPillsTabTapped,
+    required this.onSettingsTabTapped,
+  });
+
+  @override
+  Widget build(BuildContext context) {
     return PreferredSize(
       preferredSize: const Size.fromHeight(50),
       child: AppBar(
@@ -119,10 +138,10 @@ class _MainPageState extends State<MainPage> with WidgetsBindingObserver {
             switch (tabIndex) {
               case pillsToTakeTabIndex:
               case pillsTakenTabIndex:
-                _loadPillsForToday();
+                onPillsTabTapped();
                 break;
               case settingsTabIndex:
-                _updateNow();
+                onSettingsTabTapped();
                 context
                     .read<ClearPillsBloc>()
                     .add(ClearPillsEvent.updatePillsStatus);
@@ -133,51 +152,67 @@ class _MainPageState extends State<MainPage> with WidgetsBindingObserver {
     );
   }
 
-  TabBarView _mainPageTabBarView() {
+  @override
+  Size get preferredSize => const Size.fromHeight(50);
+}
+
+class _MainPageTabBarView extends StatelessWidget {
+  final DateTime now;
+  final DateService dateService;
+  final SharedPreferencesService sharedPreferencesService;
+  final VoidCallback onAddPillTapped;
+
+  const _MainPageTabBarView({
+    required this.now,
+    required this.dateService,
+    required this.sharedPreferencesService,
+    required this.onAddPillTapped,
+  });
+
+  @override
+  Widget build(BuildContext context) {
     return TabBarView(children: [
       Column(
         mainAxisAlignment: MainAxisAlignment.start,
         children: <Widget>[
           DayWidget(
-              date: _now,
+              date: now,
               mode: DayWidgetMode.toTake,
-              dateService: widget.dateService),
+              dateService: dateService),
           Align(
             alignment: Alignment.bottomRight,
             child: Padding(
               padding: const EdgeInsets.all(10.0),
-              child: Builder(builder: (context) {
-                return FloatingActionButton(
-                    onPressed: () {
-                      _updateNow();
-                      showModalBottomSheet(
-                          context: context,
-                          isScrollControlled: true,
-                          shape: const RoundedRectangleBorder(
-                            borderRadius:
-                                BorderRadius.vertical(top: Radius.circular(20)),
-                          ),
-                          builder: (context) => AddingPillForm(
-                              pillDate: _now,
-                              sharedPreferencesService:
-                                  widget.sharedPreferencesService,
-                              dateService: widget.dateService));
-                    },
-                    child: const Icon(Icons.add));
-              }),
+              child: FloatingActionButton(
+                  onPressed: () {
+                    onAddPillTapped();
+                    showModalBottomSheet(
+                        context: context,
+                        isScrollControlled: true,
+                        shape: const RoundedRectangleBorder(
+                          borderRadius:
+                              BorderRadius.vertical(top: Radius.circular(20)),
+                        ),
+                        builder: (context) => AddingPillForm(
+                            pillDate: now,
+                            sharedPreferencesService:
+                                sharedPreferencesService,
+                            dateService: dateService));
+                  },
+                  child: const Icon(Icons.add)),
             ),
           )
         ],
       ),
       Column(mainAxisAlignment: MainAxisAlignment.start, children: <Widget>[
         DayWidget(
-            date: _now,
+            date: now,
             mode: DayWidgetMode.taken,
-            dateService: widget.dateService),
+            dateService: dateService),
       ]),
       BlocBuilder<ClearPillsBloc, bool>(builder: (context, state) {
         return SettingsPage(
-            sharedPreferencesService: widget.sharedPreferencesService);
+            sharedPreferencesService: sharedPreferencesService);
       })
     ]);
   }


### PR DESCRIPTION
Resolves #80 

This pull request refactors the `MainPage` and its related widgets to improve code organization and make state management more explicit. The main changes involve extracting the app bar and tab bar view into their own stateless widgets, removing the unused `title` property, and making the handling of the current date (`now`) more flexible and testable.

**Widget structure refactor and state management improvements:**

* Extracted the AppBar and TabBarView into new stateless widgets: `_MainPageAppBar` and `_MainPageTabBarView`, passing necessary callbacks and data as parameters for better separation of concerns and easier testing.
* Updated the handling of the current date (`now`) by allowing it to be passed as an optional parameter to `_updateNow`, and propagating it through the widget tree, making state updates more explicit and testable. 

**API and parameter cleanup:**

* Removed the unused `title` property from `MainPage` and its constructor, simplifying the widget's API. 

**Callback and event handling improvements:**

* Refactored tab selection logic to use callbacks (`onPillsTabTapped`, `onSettingsTabTapped`) for better encapsulation of tab-specific actions.
* Updated the FAB (floating action button) logic to use the current date from `dateService` and notify the parent widget of changes, improving data consistency.