### PR TITLE
AddingPillForm instantiates DateService() directly instead of using an injected instance

### DIFF
--- a/lib/widget/adding_pill_form.dart
+++ b/lib/widget/adding_pill_form.dart
@@ -12,14 +12,14 @@ import 'package:pill/utils.dart';
 
 class AddingPillForm extends StatefulWidget {
   final DateTime pillDate;
-  final DateService? dateService;
+  final DateService dateService;
   final SharedPreferencesService sharedPreferencesService;
 
   const AddingPillForm(
       {super.key,
       required this.pillDate,
       required this.sharedPreferencesService,
-      this.dateService});
+      required this.dateService});
 
   @override
   AddingPillFormState createState() {
@@ -111,7 +111,7 @@ class AddingPillFormState extends State<AddingPillForm> {
 
   @override
   Widget build(BuildContext context) {
-    final dateService = widget.dateService ?? DateService();
+    final dateService = widget.dateService;
     final now = dateService.now();
     final bool isStale = dateService.formatDateForStorage(widget.pillDate) !=
         dateService.formatDateForStorage(now);

--- a/test/adding_pill_form_test.dart
+++ b/test/adding_pill_form_test.dart
@@ -27,7 +27,8 @@ void main() {
           home: Scaffold(
             body: AddingPillForm(
                 pillDate: testDate,
-                sharedPreferencesService: sharedPreferencesService),
+                sharedPreferencesService: sharedPreferencesService,
+                dateService: dateService),
           ),
         ),
       );


### PR DESCRIPTION
Resolves #81 

This pull request refactors the `AddingPillForm` widget to require a non-null `DateService` instance, improving code safety and clarity. The related test has also been updated to reflect this change.

**Widget constructor and dependency handling:**
* Changed the `AddingPillForm` constructor to require a non-null `DateService` via the `required` keyword, removing the nullable type and defaulting logic. (`lib/widget/adding_pill_form.dart`)
* Updated the widget's `build` method to use the now-required `dateService` directly, eliminating fallback to a default instance. (`lib/widget/adding_pill_form.dart`)

**Test updates:**
* Modified the test for `AddingPillForm` to provide a `dateService` argument, ensuring compatibility with the new constructor requirements. (`test/adding_pill_form_test.dart`)