### PR TITLE
Dismissing a pill card has no visual affordance and no undo — easy to accidentally delete

### DIFF
--- a/lib/bloc/pill/pill_bloc.dart
+++ b/lib/bloc/pill/pill_bloc.dart
@@ -7,7 +7,8 @@ import 'package:pill/bloc/pill/pill_state.dart';
 import 'package:pill/model/pill_to_take.dart';
 
 enum PillEvent {
-  addPill,
+  addPillRegimen,
+  addPillToDate,
   removePill,
   updatePill,
   loadPills,
@@ -38,8 +39,11 @@ class PillBloc extends Bloc<PillsEvent, PillState> {
       : super(PillState()) {
     on<PillsEvent>((event, emit) async {
       switch (event.eventName) {
-        case PillEvent.addPill:
-          await _onAddPill(event, emit);
+        case PillEvent.addPillRegimen:
+          await _onAddPillRegimen(event, emit);
+          break;
+        case PillEvent.addPillToDate:
+          await _onAddPillToDate(event, emit);
           break;
         case PillEvent.removePill:
           await _onRemovePill(event, emit);
@@ -58,7 +62,7 @@ class PillBloc extends Bloc<PillsEvent, PillState> {
     }, transformer: sequential());
   }
 
-  Future<void> _onAddPill(PillsEvent event, Emitter<PillState> emitter) async {
+  Future<void> _onAddPillRegimen(PillsEvent event, Emitter<PillState> emitter) async {
     final pillToTake = event.pillToTake;
     if (pillToTake == null) return;
 
@@ -73,6 +77,18 @@ class PillBloc extends Bloc<PillsEvent, PillState> {
 
     emitter(PillState(
       pillsToTake: pillsToTake,
+      pillsTaken: state.pillsTaken,
+    ));
+  }
+
+  Future<void> _onAddPillToDate(PillsEvent event, Emitter<PillState> emitter) async {
+    final pillToTake = event.pillToTake;
+    if (pillToTake == null) return;
+
+    final updatedPills = await _sharedPreferencesService.addPillToDate(pillToTake, event.date);
+
+    emitter(PillState(
+      pillsToTake: updatedPills,
       pillsTaken: state.pillsTaken,
     ));
   }

--- a/lib/bloc/pill/pill_bloc.dart
+++ b/lib/bloc/pill/pill_bloc.dart
@@ -7,7 +7,7 @@ import 'package:pill/bloc/pill/pill_state.dart';
 import 'package:pill/model/pill_to_take.dart';
 
 enum PillEvent {
-  addPillRegimen,
+  addPillRegiment,
   addPillToDate,
   removePill,
   updatePill,
@@ -39,8 +39,8 @@ class PillBloc extends Bloc<PillsEvent, PillState> {
       : super(PillState()) {
     on<PillsEvent>((event, emit) async {
       switch (event.eventName) {
-        case PillEvent.addPillRegimen:
-          await _onAddPillRegimen(event, emit);
+        case PillEvent.addPillRegiment:
+          await _onAddPillRegiment(event, emit);
           break;
         case PillEvent.addPillToDate:
           await _onAddPillToDate(event, emit);
@@ -62,7 +62,7 @@ class PillBloc extends Bloc<PillsEvent, PillState> {
     }, transformer: sequential());
   }
 
-  Future<void> _onAddPillRegimen(PillsEvent event, Emitter<PillState> emitter) async {
+  Future<void> _onAddPillRegiment(PillsEvent event, Emitter<PillState> emitter) async {
     final pillToTake = event.pillToTake;
     if (pillToTake == null) return;
 

--- a/lib/constants.dart
+++ b/lib/constants.dart
@@ -1,3 +1,4 @@
+const String pillIdKey = "id";
 const String pillNameKey = "pillName";
 const String pillWeightKey = "pillWeight";
 const String pillRegimentKey = "pillRegiment";

--- a/lib/model/pill_to_take.dart
+++ b/lib/model/pill_to_take.dart
@@ -6,6 +6,7 @@ import 'package:pill/constants.dart';
 const String defaultPillToTakeImage = 'assets/images/pill_to_take.png';
 
 class PillToTake extends Equatable {
+  final String id;
   final String pillName;
   final int pillRegiment;
   final String pillImage;
@@ -14,7 +15,8 @@ class PillToTake extends Equatable {
   final DateTime? lastTaken;
 
   const PillToTake(
-      {required this.pillName,
+      {required this.id,
+      required this.pillName,
       required this.pillRegiment,
       this.pillImage = defaultPillToTakeImage,
       this.description,
@@ -34,6 +36,12 @@ class PillToTake extends Equatable {
 
     final nameValue = jsonData[pillNameKey];
     final String name = nameValue is String ? nameValue : 'Unknown';
+
+    // Fallback for legacy data without ID: use name + regiment + days
+    final idValue = jsonData[pillIdKey];
+    final String id = idValue is String 
+        ? idValue 
+        : "${name}_${DateTime.now().millisecondsSinceEpoch}";
     
     final regimentValue = jsonData[pillRegimentKey];
     final int regiment = regimentValue is num 
@@ -52,6 +60,7 @@ class PillToTake extends Equatable {
         : num.tryParse(daysValue?.toString() ?? '')?.toInt() ?? 1;
 
     return PillToTake(
+        id: id,
         pillName: name,
         pillRegiment: regiment,
         pillImage: image,
@@ -61,6 +70,7 @@ class PillToTake extends Equatable {
   }
 
   static Map<String, dynamic> toMap(PillToTake pill) => {
+        pillIdKey: pill.id,
         pillNameKey: pill.pillName,
         pillRegimentKey: pill.pillRegiment,
         pillImageKey: pill.pillImage,
@@ -98,6 +108,7 @@ class PillToTake extends Equatable {
   }
 
   PillToTake copyWith({
+    String? id,
     String? pillName,
     int? pillRegiment,
     String? pillImage,
@@ -108,6 +119,7 @@ class PillToTake extends Equatable {
     bool clearLastTaken = false,
   }) {
     return PillToTake(
+      id: id ?? this.id,
       pillName: pillName ?? this.pillName,
       pillRegiment: pillRegiment ?? this.pillRegiment,
       pillImage: pillImage ?? this.pillImage,
@@ -119,6 +131,7 @@ class PillToTake extends Equatable {
 
   @override
   List<Object?> get props => [
+        id,
         pillName,
         pillRegiment,
         pillImage,

--- a/lib/service/shared_preferences_service.dart
+++ b/lib/service/shared_preferences_service.dart
@@ -435,12 +435,21 @@ class SharedPreferencesService {
   Future<void> addPillToDates(DateTime startDate, PillToTake pill) async {
     DateTime runningDate = startDate;
     int daysToTake = pill.amountOfDaysToTake;
-    final pillWithTrimmedName = pill.copyWith(pillName: pill.pillName.trim());
+    final trimmedName = pill.pillName.trim();
+    final normalizedName = trimmedName.toLowerCase();
+    final pillWithTrimmedName = pill.copyWith(pillName: trimmedName);
+
     while (daysToTake > 0) {
       String dateStr = _dateService.formatDateForStorage(runningDate);
       List<PillToTake> pills = getPillsToTakeForDate(dateStr);
-      pills.add(pillWithTrimmedName);
-      await _setPillsForDate(dateStr, pills);
+      final alreadyExists = pills.any(
+          (p) => p.pillName.trim().toLowerCase() == normalizedName);
+
+      if (!alreadyExists) {
+        pills.add(pillWithTrimmedName);
+        await _setPillsForDate(dateStr, pills);
+      }
+
       runningDate = runningDate.add(const Duration(days: oneDay));
       daysToTake--;
     }
@@ -448,6 +457,15 @@ class SharedPreferencesService {
 
   Future<List<PillToTake>> addPillToDate(PillToTake pill, String date) async {
     List<PillToTake> pills = getPillsToTakeForDate(date);
+    final normalizedName = pill.pillName.trim().toLowerCase();
+
+    final alreadyExists = pills.any(
+        (p) => p.pillName.trim().toLowerCase() == normalizedName);
+
+    if (alreadyExists) {
+      return pills;
+    }
+
     pills.add(pill.copyWith(pillName: pill.pillName.trim()));
     await _setPillsForDate(date, pills);
     return pills;

--- a/lib/service/shared_preferences_service.dart
+++ b/lib/service/shared_preferences_service.dart
@@ -446,6 +446,13 @@ class SharedPreferencesService {
     }
   }
 
+  Future<List<PillToTake>> addPillToDate(PillToTake pill, String date) async {
+    List<PillToTake> pills = getPillsToTakeForDate(date);
+    pills.add(pill.copyWith(pillName: pill.pillName.trim()));
+    await _setPillsForDate(date, pills);
+    return pills;
+  }
+
   Future<List<PillTaken>> addTakenPill(PillToTake pillToTake, String date) async {
     PillTaken pill = PillTaken.extractFromPillToTake(pillToTake);
     List<PillTaken> pillsTaken = getPillsTakenForDate(date);

--- a/lib/service/shared_preferences_service.dart
+++ b/lib/service/shared_preferences_service.dart
@@ -158,13 +158,13 @@ class SharedPreferencesService {
             final existingPills = PillToTake.decode(existingYearlyValue)
                 .map((p) => p.copyWith(pillName: p.pillName.trim()))
                 .toList();
-            // For pills to take, prefer the newer ones if names match (case-insensitive)
+            // For pills to take, prefer the newer ones if IDs match, else names (case-insensitive)
             final Map<String, PillToTake> mergedMap = {};
             for (final pill in legacyPills) {
-              mergedMap[pill.pillName.toLowerCase()] = pill;
+              mergedMap[pill.id] = pill;
             }
             for (final pill in existingPills) {
-              mergedMap[pill.pillName.toLowerCase()] = pill;
+              mergedMap[pill.id] = pill;
             }
             migratedValue = PillToTake.encode(mergedMap.values.toList());
           } else {
@@ -253,10 +253,10 @@ class SharedPreferencesService {
 
               final Map<String, PillToTake> mergedMap = {};
               for (final pill in legacyPills) {
-                mergedMap[pill.pillName.toLowerCase()] = pill;
+                mergedMap[pill.id] = pill;
               }
               for (final pill in existingPills) {
-                mergedMap[pill.pillName.toLowerCase()] = pill;
+                mergedMap[pill.id] = pill;
               }
               migratedValue = PillToTake.encode(mergedMap.values.toList());
             } else {
@@ -360,10 +360,10 @@ class SharedPreferencesService {
 
                 final Map<String, PillToTake> mergedMap = {};
                 for (final pill in legacyPills) {
-                  mergedMap[pill.pillName.toLowerCase()] = pill;
+                  mergedMap[pill.id] = pill;
                 }
                 for (final pill in existingPills) {
-                  mergedMap[pill.pillName.toLowerCase()] = pill;
+                  mergedMap[pill.id] = pill;
                 }
                 migratedValue = PillToTake.encode(mergedMap.values.toList());
               }
@@ -483,9 +483,8 @@ class SharedPreferencesService {
       updatePillForDate(PillToTake pillToTake, String currentDate) async {
     List<PillToTake> pillsToTakeList = getPillsToTakeForDate(currentDate);
 
-    final normalizedName = pillToTake.pillName.trim().toLowerCase();
     int pillIndex = pillsToTakeList.indexWhere(
-        (element) => element.pillName.trim().toLowerCase() == normalizedName);
+        (element) => element.id == pillToTake.id);
 
     if (pillIndex == -1) {
       return null;
@@ -498,7 +497,7 @@ class SharedPreferencesService {
 
     if (pillToSave.pillRegiment == 0) {
       pillsToTakeList.removeWhere(
-          (element) => element.pillName.trim().toLowerCase() == normalizedName);
+          (element) => element.id == pillToTake.id);
       await _setPillsForDate(currentDate, pillsToTakeList);
     } else {
       pillsToTakeList[pillIndex] = pillToSave;
@@ -511,9 +510,8 @@ class SharedPreferencesService {
   Future<List<PillToTake>> removePillFromDate(
       PillToTake pillToTake, String currentDate) async {
     List<PillToTake> pills = getPillsToTakeForDate(currentDate);
-    final normalizedName = pillToTake.pillName.trim().toLowerCase();
     pills.removeWhere(
-        (element) => element.pillName.trim().toLowerCase() == normalizedName);
+        (element) => element.id == pillToTake.id);
     await _setPillsForDate(currentDate, pills);
     return pills;
   }

--- a/lib/widget/adding_pill_form.dart
+++ b/lib/widget/adding_pill_form.dart
@@ -299,7 +299,7 @@ class AddingPillFormState extends State<AddingPillForm> {
                                       _pillAmountOfDaysToTakeController.text));
 
                               context.read<PillBloc>().add(PillsEvent(
-                                  eventName: PillEvent.addPill,
+                                  eventName: PillEvent.addPillRegimen,
                                   date: dateService
                                       .formatDateForStorage(effectiveDate),
                                   startDateTime: effectiveDate,

--- a/lib/widget/adding_pill_form.dart
+++ b/lib/widget/adding_pill_form.dart
@@ -287,10 +287,11 @@ class AddingPillFormState extends State<AddingPillForm> {
                             if (_formKey.currentState?.validate() ?? false) {
                               final trimmedDescription =
                                   _pillDescriptionController.text.trim();
+                              final pillName = _pillNameTextEditingController.text.trim();
 
                               PillToTake pill = PillToTake(
-                                  pillName: _pillNameTextEditingController.text
-                                      .trim(),
+                                  id: "${pillName}_${DateTime.now().millisecondsSinceEpoch}",
+                                  pillName: pillName,
                                   pillRegiment: _pillsPerDay,
                                   description: trimmedDescription.isEmpty
                                       ? ''

--- a/lib/widget/adding_pill_form.dart
+++ b/lib/widget/adding_pill_form.dart
@@ -299,7 +299,7 @@ class AddingPillFormState extends State<AddingPillForm> {
                                       _pillAmountOfDaysToTakeController.text));
 
                               context.read<PillBloc>().add(PillsEvent(
-                                  eventName: PillEvent.addPillRegimen,
+                                  eventName: PillEvent.addPillRegiment,
                                   date: dateService
                                       .formatDateForStorage(effectiveDate),
                                   startDateTime: effectiveDate,

--- a/lib/widget/day_widget.dart
+++ b/lib/widget/day_widget.dart
@@ -72,7 +72,7 @@ class DayWidget extends StatelessWidget {
                 itemBuilder: (_, index) => Dismissible(
                     key: ObjectKey(pillsToTake[index].pillName),
                     direction: DismissDirection.endToStart,
-                    background: Container(), // Not used for endToStart
+                    background: _dismissibleBackground(),
                     secondaryBackground: _dismissibleBackground(),
                     confirmDismiss: (direction) async {
                       final now = dateService.now();
@@ -81,8 +81,6 @@ class DayWidget extends StatelessWidget {
                           dateService.formatDateForStorage(date);
 
                       if (todayStr != widgetDateStr) {
-                        // Day has rolled over. Refresh the UI instead of
-                        // removing from a stale record.
                         context.read<PillBloc>().add(PillsEvent(
                             eventName: PillEvent.loadPills, date: todayStr));
                         return false;

--- a/lib/widget/day_widget.dart
+++ b/lib/widget/day_widget.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:pill/bloc/pill/pill_bloc.dart';
@@ -199,7 +200,13 @@ class _DayWidgetState extends State<DayWidget> {
               child: BlocConsumer<PillBloc, PillState>(
                 listenWhen: (previous, current) {
                   return widget.mode == DayWidgetMode.toTake &&
-                      previous.pillsToTake != current.pillsToTake;
+                      !listEquals(previous.pillsToTake, current.pillsToTake);
+                },
+                buildWhen: (previous, current) {
+                  if (widget.mode == DayWidgetMode.toTake) {
+                    return !listEquals(previous.pillsToTake, current.pillsToTake);
+                  }
+                  return !listEquals(previous.pillsTaken, current.pillsTaken);
                 },
                 listener: (context, state) {
                   setState(() {

--- a/lib/widget/day_widget.dart
+++ b/lib/widget/day_widget.dart
@@ -13,19 +13,40 @@ const double listItemHeight = 200.0;
 
 enum DayWidgetMode { toTake, taken }
 
-class DayWidget extends StatelessWidget {
+class DayWidget extends StatefulWidget {
   const DayWidget(
       {super.key,
-      required this.date,
-      required this.mode,
-      required this.dateService});
+        required this.date,
+        required this.mode,
+        required this.dateService});
 
   final DateTime date;
   final DayWidgetMode mode;
   final DateService dateService;
 
-  String get _header =>
-      mode == DayWidgetMode.toTake ? pillsToTakeHeader : pillsTakenHeader;
+  @override
+  State<DayWidget> createState() => _DayWidgetState();
+}
+
+class _DayWidgetState extends State<DayWidget> {
+  // Local copy of the pill list, kept in sync with bloc via BlocConsumer.
+  // Mutated immediately on dismiss so Dismissible is satisfied synchronously.
+  List<PillToTake>? _localPills;
+
+  String get _header => widget.mode == DayWidgetMode.toTake
+      ? pillsToTakeHeader
+      : pillsTakenHeader;
+
+  @override
+  void initState() {
+    super.initState();
+    // Initialize immediately from current bloc state so the list
+    // is populated on the very first build, before any listener fires.
+    final currentState = context.read<PillBloc>().state;
+    if (currentState.pillsToTake != null) {
+      _localPills = List.from(currentState.pillsToTake!);
+    }
+  }
 
   Widget _dismissibleBackground() {
     return Container(
@@ -57,72 +78,83 @@ class DayWidget extends StatelessWidget {
     );
   }
 
-  Widget _pillsToTakeList(BuildContext context, PillState state) {
-    List<PillToTake>? pillsToTake = state.pillsToTake;
-    return (pillsToTake == null || pillsToTake.isEmpty)
-        ? Padding(
-            padding: const EdgeInsets.only(top: 20),
-            child: Text(_header,
-                style:
-                    const TextStyle(fontSize: 20, fontWeight: FontWeight.bold)))
-        : SizedBox(
-            height: listItemHeight,
-            child: ListView.builder(
-                itemCount: pillsToTake.length,
-                itemBuilder: (_, index) => Dismissible(
-                    key: ObjectKey(pillsToTake[index].pillName),
-                    direction: DismissDirection.endToStart,
-                    background: _dismissibleBackground(),
-                    secondaryBackground: _dismissibleBackground(),
-                    confirmDismiss: (direction) async {
-                      final now = dateService.now();
-                      final todayStr = dateService.formatDateForStorage(now);
-                      final widgetDateStr =
-                          dateService.formatDateForStorage(date);
+  Widget _pillsToTakeList(BuildContext context) {
+    final pills = _localPills;
+    if (pills == null || pills.isEmpty) {
+      return Padding(
+          padding: const EdgeInsets.only(top: 20),
+          child: Text(_header,
+              style:
+              const TextStyle(fontSize: 20, fontWeight: FontWeight.bold)));
+    }
 
-                      if (todayStr != widgetDateStr) {
-                        context.read<PillBloc>().add(PillsEvent(
-                            eventName: PillEvent.loadPills, date: todayStr));
-                        return false;
-                      }
-                      return true;
-                    },
-                    onDismissed: (direction) {
-                      final widgetDateStr =
-                          dateService.formatDateForStorage(date);
-                      final removedPill = pillsToTake[index];
+    return SizedBox(
+      height: listItemHeight,
+      child: ListView.builder(
+        itemCount: pills.length,
+        itemBuilder: (_, index) {
+          final pill = pills[index];
+          return Dismissible(
+            key: ObjectKey(pill.pillName),
+            direction: DismissDirection.endToStart,
+            background: _dismissibleBackground(),
+            secondaryBackground: _dismissibleBackground(),
+            confirmDismiss: (direction) async {
+              final now = widget.dateService.now();
+              final todayStr = widget.dateService.formatDateForStorage(now);
+              final widgetDateStr =
+              widget.dateService.formatDateForStorage(widget.date);
 
+              if (todayStr != widgetDateStr) {
+                context.read<PillBloc>().add(PillsEvent(
+                    eventName: PillEvent.loadPills, date: todayStr));
+                return false;
+              }
+              return true;
+            },
+            onDismissed: (direction) {
+              final widgetDateStr =
+              widget.dateService.formatDateForStorage(widget.date);
+
+              // Immediately remove from local list — required by Dismissible
+              setState(() => _localPills!.remove(pill));
+
+              context.read<PillBloc>().add(PillsEvent(
+                  eventName: PillEvent.removePill,
+                  date: widgetDateStr,
+                  pillToTake: pill));
+
+              ScaffoldMessenger.of(context).hideCurrentSnackBar();
+              ScaffoldMessenger.of(context).showSnackBar(
+                SnackBar(
+                  content: Text('${pill.pillName} removed'),
+                  behavior: SnackBarBehavior.floating,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(10),
+                  ),
+                  action: SnackBarAction(
+                    label: 'Undo',
+                    onPressed: () {
                       context.read<PillBloc>().add(PillsEvent(
-                          eventName: PillEvent.removePill,
+                          eventName: PillEvent.addPillToDate,
                           date: widgetDateStr,
-                          pillToTake: removedPill));
-
-                      ScaffoldMessenger.of(context).hideCurrentSnackBar();
-                      ScaffoldMessenger.of(context).showSnackBar(
-                        SnackBar(
-                          content: Text('${removedPill.pillName} removed'),
-                          behavior: SnackBarBehavior.floating,
-                          shape: RoundedRectangleBorder(
-                            borderRadius: BorderRadius.circular(10),
-                          ),
-                          action: SnackBarAction(
-                            label: 'Undo',
-                            onPressed: () {
-                              context.read<PillBloc>().add(PillsEvent(
-                                  eventName: PillEvent.addPillToDate,
-                                  date: widgetDateStr,
-                                  pillToTake: removedPill));
-                            },
-                          ),
-                        ),
-                      );
+                          pillToTake: pill));
+                      // _localPills will be updated by BlocConsumer listener
+                      // when the bloc emits the restored state
                     },
-                    child: PillWidget(
-                      pillToTake: pillsToTake[index],
-                      dateService: dateService,
-                      date: date,
-                    ))),
+                  ),
+                ),
+              );
+            },
+            child: PillWidget(
+              pillToTake: pill,
+              dateService: widget.dateService,
+              date: widget.date,
+            ),
           );
+        },
+      ),
+    );
   }
 
   Widget _pillsTakenList(BuildContext context, PillState state) {
@@ -132,7 +164,7 @@ class DayWidget extends StatelessWidget {
           padding: const EdgeInsets.only(top: 20),
           child: Text(_header,
               style:
-                  const TextStyle(fontSize: 20, fontWeight: FontWeight.bold)));
+              const TextStyle(fontSize: 20, fontWeight: FontWeight.bold)));
     }
 
     return SizedBox(
@@ -140,39 +172,48 @@ class DayWidget extends StatelessWidget {
         child: ListView.builder(
           itemCount: pillsTaken.length,
           itemBuilder: (_, index) => PillTakenWidget(
-              pillTaken: pillsTaken[index], dateService: dateService),
+              pillTaken: pillsTaken[index], dateService: widget.dateService),
         ));
   }
 
   @override
   Widget build(BuildContext context) {
     return Expanded(
-        child: SizedBox(
-      height: double.infinity,
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.start,
-        crossAxisAlignment: CrossAxisAlignment.center,
-        children: [
-          Align(
-            alignment: Alignment.topCenter,
-            child: Padding(
-              padding: const EdgeInsets.only(top: 40.0),
-              child: Text(dateService.formatDateForDisplay(date),
-                  style: const TextStyle(
-                      fontSize: 25.0, fontWeight: FontWeight.bold)),
+      child: SizedBox(
+        height: double.infinity,
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.start,
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            Align(
+              alignment: Alignment.topCenter,
+              child: Padding(
+                padding: const EdgeInsets.only(top: 40.0),
+                child: Text(
+                    widget.dateService.formatDateForDisplay(widget.date),
+                    style: const TextStyle(
+                        fontSize: 25.0, fontWeight: FontWeight.bold)),
+              ),
             ),
-          ),
-          Expanded(
-            child: BlocBuilder<PillBloc, PillState>(
-              builder: (context, state) {
-                return (mode == DayWidgetMode.toTake)
-                    ? _pillsToTakeList(context, state)
-                    : _pillsTakenList(context, state);
-              },
+            Expanded(
+              child: BlocConsumer<PillBloc, PillState>(
+                listener: (context, state) {
+                  setState(() {
+                    _localPills = state.pillsToTake != null
+                        ? List.from(state.pillsToTake!)
+                        : [];
+                  });
+                },
+                builder: (context, state) {
+                  return (widget.mode == DayWidgetMode.toTake)
+                      ? _pillsToTakeList(context)
+                      : _pillsTakenList(context, state);
+                },
+              ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
-    ));
+    );
   }
 }

--- a/lib/widget/day_widget.dart
+++ b/lib/widget/day_widget.dart
@@ -96,7 +96,7 @@ class _DayWidgetState extends State<DayWidget> {
         itemBuilder: (_, index) {
           final pill = pills[index];
           return Dismissible(
-            key: ValueKey(pill.pillName),
+            key: ValueKey(pill.id),
             direction: DismissDirection.endToStart,
             background: const SizedBox.shrink(),
             secondaryBackground: _dismissibleBackground(),
@@ -214,9 +214,14 @@ class _DayWidgetState extends State<DayWidget> {
                       : <PillToTake>[];
                   final localPills = _localPills ?? <PillToTake>[];
 
+                  // We check by id because full PillToTake equality includes mutable fields
+                  // like pillRegiment and lastTaken. If we used .contains(pill), any update
+                  // (e.g. tapping a pill) would look like a "new" pill not in localPills,
+                  // triggering this guard and preventing the UI from reflecting the update.
                   final blocWouldReintroduceLocallyRemovedPills =
                       localPills.isNotEmpty &&
-                          blocPills.any((pill) => !localPills.contains(pill));
+                          blocPills.any((pill) =>
+                          !localPills.any((local) => local.id == pill.id));
 
                   if (blocWouldReintroduceLocallyRemovedPills) {
                     return;

--- a/lib/widget/day_widget.dart
+++ b/lib/widget/day_widget.dart
@@ -209,10 +209,21 @@ class _DayWidgetState extends State<DayWidget> {
                   return !listEquals(previous.pillsTaken, current.pillsTaken);
                 },
                 listener: (context, state) {
+                  final blocPills = state.pillsToTake != null
+                      ? List<PillToTake>.from(state.pillsToTake!)
+                      : <PillToTake>[];
+                  final localPills = _localPills ?? <PillToTake>[];
+
+                  final blocWouldReintroduceLocallyRemovedPills =
+                      localPills.isNotEmpty &&
+                          blocPills.any((pill) => !localPills.contains(pill));
+
+                  if (blocWouldReintroduceLocallyRemovedPills) {
+                    return;
+                  }
+
                   setState(() {
-                    _localPills = state.pillsToTake != null
-                        ? List.from(state.pillsToTake!)
-                        : [];
+                    _localPills = blocPills;
                   });
                 },
                 builder: (context, state) {

--- a/lib/widget/day_widget.dart
+++ b/lib/widget/day_widget.dart
@@ -54,12 +54,12 @@ class _DayWidgetState extends State<DayWidget> {
       decoration: BoxDecoration(
         gradient: LinearGradient(
           colors: [Colors.red.shade400, Colors.red.shade700],
-          begin: Alignment.centerLeft,
-          end: Alignment.centerRight,
+          begin: AlignmentDirectional.centerStart,
+          end: AlignmentDirectional.centerEnd,
         ),
         borderRadius: BorderRadius.circular(12),
       ),
-      alignment: Alignment.centerRight,
+      alignment: AlignmentDirectional.centerEnd,
       padding: const EdgeInsets.symmetric(horizontal: 24),
       child: const Row(
         mainAxisAlignment: MainAxisAlignment.end,
@@ -97,7 +97,7 @@ class _DayWidgetState extends State<DayWidget> {
           return Dismissible(
             key: ObjectKey(pill.pillName),
             direction: DismissDirection.endToStart,
-            background: _dismissibleBackground(),
+            background: const SizedBox.shrink(),
             secondaryBackground: _dismissibleBackground(),
             confirmDismiss: (direction) async {
               final now = widget.dateService.now();

--- a/lib/widget/day_widget.dart
+++ b/lib/widget/day_widget.dart
@@ -95,7 +95,7 @@ class _DayWidgetState extends State<DayWidget> {
         itemBuilder: (_, index) {
           final pill = pills[index];
           return Dismissible(
-            key: ObjectKey(pill.pillName),
+            key: ValueKey(pill.pillName),
             direction: DismissDirection.endToStart,
             background: const SizedBox.shrink(),
             secondaryBackground: _dismissibleBackground(),
@@ -197,6 +197,10 @@ class _DayWidgetState extends State<DayWidget> {
             ),
             Expanded(
               child: BlocConsumer<PillBloc, PillState>(
+                listenWhen: (previous, current) {
+                  return widget.mode == DayWidgetMode.toTake &&
+                      previous.pillsToTake != current.pillsToTake;
+                },
                 listener: (context, state) {
                   setState(() {
                     _localPills = state.pillsToTake != null

--- a/lib/widget/day_widget.dart
+++ b/lib/widget/day_widget.dart
@@ -27,6 +27,36 @@ class DayWidget extends StatelessWidget {
   String get _header =>
       mode == DayWidgetMode.toTake ? pillsToTakeHeader : pillsTakenHeader;
 
+  Widget _dismissibleBackground() {
+    return Container(
+      margin: const EdgeInsets.symmetric(vertical: 5, horizontal: 5),
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          colors: [Colors.red.shade400, Colors.red.shade700],
+          begin: Alignment.centerLeft,
+          end: Alignment.centerRight,
+        ),
+        borderRadius: BorderRadius.circular(12),
+      ),
+      alignment: Alignment.centerRight,
+      padding: const EdgeInsets.symmetric(horizontal: 24),
+      child: const Row(
+        mainAxisAlignment: MainAxisAlignment.end,
+        children: [
+          Text(
+            "Delete",
+            style: TextStyle(
+                color: Colors.white,
+                fontSize: 16,
+                fontWeight: FontWeight.w600),
+          ),
+          SizedBox(width: 12),
+          Icon(Icons.delete_outline, color: Colors.white, size: 28),
+        ],
+      ),
+    );
+  }
+
   Widget _pillsToTakeList(BuildContext context, PillState state) {
     List<PillToTake>? pillsToTake = state.pillsToTake;
     return (pillsToTake == null || pillsToTake.isEmpty)
@@ -41,6 +71,9 @@ class DayWidget extends StatelessWidget {
                 itemCount: pillsToTake.length,
                 itemBuilder: (_, index) => Dismissible(
                     key: ObjectKey(pillsToTake[index].pillName),
+                    direction: DismissDirection.endToStart,
+                    background: Container(), // Not used for endToStart
+                    secondaryBackground: _dismissibleBackground(),
                     confirmDismiss: (direction) async {
                       final now = dateService.now();
                       final todayStr = dateService.formatDateForStorage(now);
@@ -59,11 +92,32 @@ class DayWidget extends StatelessWidget {
                     onDismissed: (direction) {
                       final widgetDateStr =
                           dateService.formatDateForStorage(date);
+                      final removedPill = pillsToTake[index];
 
                       context.read<PillBloc>().add(PillsEvent(
                           eventName: PillEvent.removePill,
                           date: widgetDateStr,
-                          pillToTake: pillsToTake[index]));
+                          pillToTake: removedPill));
+
+                      ScaffoldMessenger.of(context).hideCurrentSnackBar();
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        SnackBar(
+                          content: Text('${removedPill.pillName} removed'),
+                          behavior: SnackBarBehavior.floating,
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(10),
+                          ),
+                          action: SnackBarAction(
+                            label: 'Undo',
+                            onPressed: () {
+                              context.read<PillBloc>().add(PillsEvent(
+                                  eventName: PillEvent.addPillToDate,
+                                  date: widgetDateStr,
+                                  pillToTake: removedPill));
+                            },
+                          ),
+                        ),
+                      );
                     },
                     child: PillWidget(
                       pillToTake: pillsToTake[index],

--- a/test/day_widget_rollover_test.dart
+++ b/test/day_widget_rollover_test.dart
@@ -45,6 +45,7 @@ void main() {
   late SharedPreferencesService sharedPreferencesService;
   final DateTime widgetDate = DateTime(2023, 1, 1);
   const testPill = PillToTake(
+      id: '1',
       pillName: "Test Pill",
       pillRegiment: 1,
       amountOfDaysToTake: 1);

--- a/test/day_widget_test.dart
+++ b/test/day_widget_test.dart
@@ -11,18 +11,29 @@ import 'package:pill/widget/pill_to_take_widget.dart';
 import 'package:pill/widget/pill_taken_widget.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+class MockDateService extends DateService {
+  final DateTime _now;
+  MockDateService(this._now);
+  @override
+  DateTime now() => _now;
+}
+
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   late PillBloc pillBloc;
   late SharedPreferencesService sharedPreferencesService;
-  final dateService = DateService();
+  late DateService dateService;
 
   final testDate = DateTime(2023, 10, 10);
-  final testDateStorageStr = dateService.formatDateForStorage(testDate);
-  final testDateDisplayStr = dateService.formatDateForDisplay(testDate);
+  late String testDateStorageStr;
+  late String testDateDisplayStr;
 
   setUp(() async {
+    dateService = MockDateService(testDate);
+    testDateStorageStr = dateService.formatDateForStorage(testDate);
+    testDateDisplayStr = dateService.formatDateForDisplay(testDate);
+    
     SharedPreferences.setMockInitialValues({});
     sharedPreferencesService =
         await SharedPreferencesService.create(dateService);
@@ -141,5 +152,68 @@ void main() {
     await tester.pumpAndSettle();
 
     expect(tester.takeException(), isNull);
+  });
+
+  testWidgets('DayWidget dismisses pill, shows SnackBar, and undos',
+          (WidgetTester tester) async {
+        const pill = PillToTake(
+            pillName: "Dismiss Pill", pillRegiment: 1, amountOfDaysToTake: 1);
+
+        await seedBlocState(tester, () async {
+          await sharedPreferencesService.addPillToDates(testDate, pill);
+        });
+
+        await tester.pumpWidget(createWidgetUnderTest(mode: DayWidgetMode.toTake));
+        await tester.pumpAndSettle();
+
+        expect(find.byType(PillWidget), findsOneWidget);
+
+        // Swipe right to left (end to start) to dismiss
+        await tester.drag(find.byType(Dismissible), const Offset(-500, 0));
+        await tester.pumpAndSettle();
+
+        // Verify pill is gone and SnackBar is shown
+        expect(find.byType(PillWidget), findsNothing);
+        expect(find.text("Dismiss Pill removed"), findsOneWidget);
+        expect(find.text("Undo"), findsOneWidget);
+
+        // Tap Undo and wait for the bloc to emit the restored state
+        await tester.runAsync(() async {
+          await tester.tap(find.text("Undo"));
+          await pillBloc.stream.first;   // ← wait for addPillToDate → loadPills state
+        });
+
+        await tester.pump();
+        await tester.pumpAndSettle();
+
+        // Verify pill is back
+        expect(find.byType(PillWidget), findsOneWidget);
+        expect(find.text("Dismiss Pill"), findsOneWidget);
+      });
+
+  testWidgets('DayWidget swipe start-to-end does NOT dismiss',
+      (WidgetTester tester) async {
+    const pill = PillToTake(
+        pillName: "No Dismiss Pill", pillRegiment: 1, amountOfDaysToTake: 1);
+
+    await seedBlocState(tester, () async {
+      await sharedPreferencesService.addPillToDates(testDate, pill);
+    });
+
+    await tester.pumpWidget(createWidgetUnderTest(mode: DayWidgetMode.toTake));
+    await tester.pump();
+    await tester.pumpAndSettle();
+
+    expect(find.byType(PillWidget), findsOneWidget);
+
+    // Swipe left to right (start to end)
+    await tester.drag(find.byType(Dismissible), const Offset(500, 0));
+    // Settle the "bounce back" animation since it won't dismiss
+    await tester.pumpAndSettle();
+
+    // Verify pill is STILL there
+    expect(find.byType(PillWidget), findsOneWidget);
+    expect(find.text("No Dismiss Pill"), findsOneWidget);
+    expect(find.text("No Dismiss Pill removed"), findsNothing);
   });
 }

--- a/test/day_widget_test.dart
+++ b/test/day_widget_test.dart
@@ -176,8 +176,9 @@ void main() {
         expect(find.text("Dismiss Pill removed"), findsOneWidget);
         expect(find.text("Undo"), findsOneWidget);
 
-        // Wait for TWO emissions: addPill state + subsequent loadPills state
-        final stateAfterUndo = pillBloc.stream.skip(1).first;
+        final stateAfterUndo = pillBloc.stream.firstWhere(
+              (state) => state.pillsToTake?.any((p) => p.pillName == "Dismiss Pill") ?? false,
+        );
 
         await tester.tap(find.text("Undo"));
         await tester.runAsync(() => stateAfterUndo);

--- a/test/day_widget_test.dart
+++ b/test/day_widget_test.dart
@@ -91,7 +91,7 @@ void main() {
     // 2. Write to service synchronously, then drive bloc state update via
     //    tester.runAsync so the stream emission fully completes
     const pill = PillToTake(
-        pillName: "Test Pill", pillRegiment: 1, amountOfDaysToTake: 1);
+        id: "test_id", pillName: "Test Pill", pillRegiment: 1, amountOfDaysToTake: 1);
 
     await seedBlocState(tester, () async {
       await sharedPreferencesService.addPillToDates(testDate, pill);
@@ -115,7 +115,7 @@ void main() {
     expect(find.text(pillsTakenHeader), findsOneWidget);
 
     const pill = PillToTake(
-        pillName: "Taken Pill", pillRegiment: 1, amountOfDaysToTake: 1);
+        id: "taken_id", pillName: "Taken Pill", pillRegiment: 1, amountOfDaysToTake: 1);
 
     // 2. Add AND mark taken synchronously in the service, then drive bloc state
     await seedBlocState(tester, () async {
@@ -145,7 +145,7 @@ void main() {
       await sharedPreferencesService.addPillToDates(
           testDate,
           const PillToTake(
-              pillName: "Layout Pill", pillRegiment: 1, amountOfDaysToTake: 1));
+              id: "layout_id", pillName: "Layout Pill", pillRegiment: 1, amountOfDaysToTake: 1));
     });
 
     await tester.pump();
@@ -157,7 +157,7 @@ void main() {
   testWidgets('DayWidget dismisses pill, shows SnackBar, and undos',
       (WidgetTester tester) async {
     const pill = PillToTake(
-        pillName: "Dismiss Pill", pillRegiment: 1, amountOfDaysToTake: 1);
+        id: "dismiss_id", pillName: "Dismiss Pill", pillRegiment: 1, amountOfDaysToTake: 1);
 
     await seedBlocState(tester, () async {
       await sharedPreferencesService.addPillToDates(testDate, pill);
@@ -191,7 +191,7 @@ void main() {
   testWidgets('DayWidget swipe start-to-end does NOT dismiss',
       (WidgetTester tester) async {
     const pill = PillToTake(
-        pillName: "No Dismiss Pill", pillRegiment: 1, amountOfDaysToTake: 1);
+        id: "no_dismiss_id", pillName: "No Dismiss Pill", pillRegiment: 1, amountOfDaysToTake: 1);
 
     await seedBlocState(tester, () async {
       await sharedPreferencesService.addPillToDates(testDate, pill);

--- a/test/day_widget_test.dart
+++ b/test/day_widget_test.dart
@@ -180,7 +180,7 @@ void main() {
         // Tap Undo and wait for the bloc to emit the restored state
         await tester.runAsync(() async {
           await tester.tap(find.text("Undo"));
-          await pillBloc.stream.first;   // ← wait for addPillToDate → loadPills state
+          await pillBloc.stream.first;   // Wait for the restored state emitted by addPillToDate.
         });
 
         await tester.pump();

--- a/test/day_widget_test.dart
+++ b/test/day_widget_test.dart
@@ -109,8 +109,9 @@ void main() {
     // 2. Add AND mark taken synchronously in the service, then drive bloc state
     await seedBlocState(tester, () async {
       await sharedPreferencesService.addPillToDates(testDate, pill);
-      await sharedPreferencesService.updatePillForDate(
-          pill.copyWith(pillRegiment: 0, lastTaken: testDate), testDateStorageStr);
+      // Create the pill in state exactly as updatePillForDate would
+      final updatedPill = pill.copyWith(pillRegiment: 0, lastTaken: testDate);
+      await sharedPreferencesService.updatePillForDate(updatedPill, testDateStorageStr);
     });
 
     await tester.pump();

--- a/test/day_widget_test.dart
+++ b/test/day_widget_test.dart
@@ -168,25 +168,21 @@ void main() {
 
         expect(find.byType(PillWidget), findsOneWidget);
 
-        // Swipe right to left (end to start) to dismiss
+        // Swipe right to left to dismiss
         await tester.drag(find.byType(Dismissible), const Offset(-500, 0));
         await tester.pumpAndSettle();
 
-        // Verify pill is gone and SnackBar is shown
         expect(find.byType(PillWidget), findsNothing);
         expect(find.text("Dismiss Pill removed"), findsOneWidget);
         expect(find.text("Undo"), findsOneWidget);
 
-        // Tap Undo and wait for the bloc to emit the restored state
-        await tester.runAsync(() async {
-          await tester.tap(find.text("Undo"));
-          await pillBloc.stream.first;   // Wait for the restored state emitted by addPillToDate.
-        });
+        // Wait for TWO emissions: addPill state + subsequent loadPills state
+        final stateAfterUndo = pillBloc.stream.skip(1).first;
 
-        await tester.pump();
+        await tester.tap(find.text("Undo"));
+        await tester.runAsync(() => stateAfterUndo);
         await tester.pumpAndSettle();
 
-        // Verify pill is back
         expect(find.byType(PillWidget), findsOneWidget);
         expect(find.text("Dismiss Pill"), findsOneWidget);
       });

--- a/test/day_widget_test.dart
+++ b/test/day_widget_test.dart
@@ -155,38 +155,38 @@ void main() {
   });
 
   testWidgets('DayWidget dismisses pill, shows SnackBar, and undos',
-          (WidgetTester tester) async {
-        const pill = PillToTake(
-            pillName: "Dismiss Pill", pillRegiment: 1, amountOfDaysToTake: 1);
+      (WidgetTester tester) async {
+    const pill = PillToTake(
+        pillName: "Dismiss Pill", pillRegiment: 1, amountOfDaysToTake: 1);
 
-        await seedBlocState(tester, () async {
-          await sharedPreferencesService.addPillToDates(testDate, pill);
-        });
+    await seedBlocState(tester, () async {
+      await sharedPreferencesService.addPillToDates(testDate, pill);
+    });
 
-        await tester.pumpWidget(createWidgetUnderTest(mode: DayWidgetMode.toTake));
-        await tester.pumpAndSettle();
+    await tester.pumpWidget(createWidgetUnderTest(mode: DayWidgetMode.toTake));
+    await tester.pumpAndSettle();
 
-        expect(find.byType(PillWidget), findsOneWidget);
+    expect(find.byType(PillWidget), findsOneWidget);
 
-        // Swipe right to left to dismiss
-        await tester.drag(find.byType(Dismissible), const Offset(-500, 0));
-        await tester.pumpAndSettle();
+    // Swipe right to left to dismiss
+    await tester.drag(find.byType(Dismissible), const Offset(-500, 0));
+    await tester.pumpAndSettle();
 
-        expect(find.byType(PillWidget), findsNothing);
-        expect(find.text("Dismiss Pill removed"), findsOneWidget);
-        expect(find.text("Undo"), findsOneWidget);
+    expect(find.byType(PillWidget), findsNothing);
+    expect(find.text("Dismiss Pill removed"), findsOneWidget);
+    expect(find.text("Undo"), findsOneWidget);
 
-        final stateAfterUndo = pillBloc.stream.firstWhere(
-              (state) => state.pillsToTake?.any((p) => p.pillName == "Dismiss Pill") ?? false,
-        );
+    final stateAfterUndo = pillBloc.stream.firstWhere(
+      (state) => state.pillsToTake?.any((p) => p.pillName == "Dismiss Pill") ?? false,
+    );
 
-        await tester.tap(find.text("Undo"));
-        await tester.runAsync(() => stateAfterUndo);
-        await tester.pumpAndSettle();
+    await tester.tap(find.text("Undo"));
+    await tester.runAsync(() => stateAfterUndo);
+    await tester.pumpAndSettle();
 
-        expect(find.byType(PillWidget), findsOneWidget);
-        expect(find.text("Dismiss Pill"), findsOneWidget);
-      });
+    expect(find.byType(PillWidget), findsOneWidget);
+    expect(find.text("Dismiss Pill"), findsOneWidget);
+  });
 
   testWidgets('DayWidget swipe start-to-end does NOT dismiss',
       (WidgetTester tester) async {

--- a/test/pill_taken_test.dart
+++ b/test/pill_taken_test.dart
@@ -7,6 +7,7 @@ void main() {
   group('PillTaken.extractFromPillToTake', () {
     test('should use defaultPillTakenImage when PillToTake has defaultPillToTakeImage', () {
       const pillToTake = PillToTake(
+        id: '1',
         pillName: 'Test Pill',
         pillRegiment: 1,
         amountOfDaysToTake: 1,
@@ -21,6 +22,7 @@ void main() {
     test('should preserve custom image from PillToTake', () {
       const customImage = 'assets/images/custom_pill.png';
       const pillToTake = PillToTake(
+        id: '1',
         pillName: 'Test Pill',
         pillRegiment: 1,
         amountOfDaysToTake: 1,

--- a/test/pill_to_take_test.dart
+++ b/test/pill_to_take_test.dart
@@ -5,6 +5,7 @@ import 'package:pill/constants.dart';
 void main() {
   group('PillToTake copyWith', () {
     const pill = PillToTake(
+      id: 'test_id',
       pillName: 'Test',
       pillRegiment: 1,
       amountOfDaysToTake: 1,
@@ -14,6 +15,7 @@ void main() {
     test('should update fields correctly', () {
       final updated = pill.copyWith(pillName: 'Updated');
       expect(updated.pillName, 'Updated');
+      expect(updated.id, 'test_id');
       expect(updated.description, 'Original Description');
     });
 
@@ -39,6 +41,7 @@ void main() {
   group('PillToTake.fromJson', () {
     test('should parse numeric values from double', () {
       final json = {
+        pillIdKey: 'test_id',
         pillNameKey: 'Test Pill',
         pillRegimentKey: 2.0,
         pillAmountOfDaysToTakeKey: 7.0,
@@ -46,12 +49,14 @@ void main() {
 
       final pill = PillToTake.fromJson(json);
 
+      expect(pill.id, 'test_id');
       expect(pill.pillRegiment, 2);
       expect(pill.amountOfDaysToTake, 7);
     });
 
     test('should parse numeric values from string double', () {
       final json = {
+        pillIdKey: 'test_id',
         pillNameKey: 'Test Pill',
         pillRegimentKey: '2.0',
         pillAmountOfDaysToTakeKey: '7.0',
@@ -59,6 +64,7 @@ void main() {
 
       final pill = PillToTake.fromJson(json);
 
+      expect(pill.id, 'test_id');
       expect(pill.pillRegiment, 2);
       expect(pill.amountOfDaysToTake, 7);
     });
@@ -86,6 +92,7 @@ void main() {
       expect(pill.description, isNull);
       expect(pill.amountOfDaysToTake, 1);
       expect(pill.lastTaken, isNull);
+      expect(pill.id, startsWith('Unknown_'));
     });
 
     test('should handle wrong-typed fields with defaults', () {
@@ -105,15 +112,18 @@ void main() {
       expect(pill.description, isNull);
       expect(pill.amountOfDaysToTake, 1);
       expect(pill.lastTaken, isNull);
+      expect(pill.id, startsWith('Unknown_'));
     });
 
     test('should parse valid lastTaken date', () {
       const dateString = '2023-10-27T10:00:00.000Z';
       final json = <String, dynamic>{
+        pillIdKey: 'test_id',
         pillLastTakenKey: dateString
       };
       final pill = PillToTake.fromJson(json);
 
+      expect(pill.id, 'test_id');
       expect(pill.lastTaken, DateTime.parse(dateString));
     });
   });
@@ -132,9 +142,10 @@ void main() {
     });
 
     test('should return list of PillToTake for valid JSON list', () {
-      const validJson = '[{"pillName": "Advil", "pillRegiment": 2, "amountOfDaysToTake": 7}]';
+      const validJson = '[{"id": "id1", "pillName": "Advil", "pillRegiment": 2, "amountOfDaysToTake": 7}]';
       final result = PillToTake.decode(validJson);
       expect(result.length, 1);
+      expect(result[0].id, 'id1');
       expect(result[0].pillName, 'Advil');
       expect(result[0].pillRegiment, 2);
     });

--- a/test/pill_widget_rollover_test.dart
+++ b/test/pill_widget_rollover_test.dart
@@ -54,6 +54,7 @@ void main() {
           home: Scaffold(
             body: PillWidget(
               pillToTake: const PillToTake(
+                  id: '1',
                   pillName: "Test Pill",
                   pillRegiment: 1,
                   amountOfDaysToTake: 1),

--- a/test/pill_widget_test.dart
+++ b/test/pill_widget_test.dart
@@ -106,7 +106,7 @@ void main() async {
 
     BuildContext context = tester.element(find.byType(Scaffold));
     context.read<PillBloc>().add(PillsEvent(
-        eventName: PillEvent.addPill,
+        eventName: PillEvent.addPillRegimen,
         date: currentDateStorage,
         startDateTime: date,
         pillToTake: pillWithInfo));
@@ -143,7 +143,7 @@ void main() async {
 
     BuildContext context = tester.element(find.byType(Scaffold));
     context.read<PillBloc>().add(PillsEvent(
-        eventName: PillEvent.addPill,
+        eventName: PillEvent.addPillRegimen,
         date: currentDateStorage,
         startDateTime: date,
         pillToTake: pillWithInfo));
@@ -167,7 +167,7 @@ void main() async {
 
     BuildContext context = tester.element(find.byType(Scaffold));
     context.read<PillBloc>().add(PillsEvent(
-        eventName: PillEvent.addPill,
+        eventName: PillEvent.addPillRegimen,
         date: currentDateStorage,
         startDateTime: date,
         pillToTake: pillToTake));

--- a/test/pill_widget_test.dart
+++ b/test/pill_widget_test.dart
@@ -96,6 +96,7 @@ void main() async {
 
   testWidgets("Pill Widget - Info Icon Display and Tooltip", (WidgetTester tester) async {
     const PillToTake pillWithInfo = PillToTake(
+        id: '1',
         pillRegiment: 1, 
         pillName: "Info Pill", 
         amountOfDaysToTake: 1,
@@ -133,6 +134,7 @@ void main() async {
 
   testWidgets("Pill Widget - Event Isolation (Info tap doesn't take pill)", (WidgetTester tester) async {
     const PillToTake pillWithInfo = PillToTake(
+        id: '2',
         pillRegiment: 1, 
         pillName: "Safe Pill", 
         amountOfDaysToTake: 1,
@@ -160,7 +162,7 @@ void main() async {
 
   testWidgets("Pill Widget - Taking a Pill", (WidgetTester tester) async {
     const PillToTake pillToTake = PillToTake(
-        pillRegiment: 1, pillName: "Action Pill", amountOfDaysToTake: 1);
+        id: '3', pillRegiment: 1, pillName: "Action Pill", amountOfDaysToTake: 1);
 
     await tester.pumpWidget(base);
     await tester.pumpAndSettle();

--- a/test/pill_widget_test.dart
+++ b/test/pill_widget_test.dart
@@ -106,7 +106,7 @@ void main() async {
 
     BuildContext context = tester.element(find.byType(Scaffold));
     context.read<PillBloc>().add(PillsEvent(
-        eventName: PillEvent.addPillRegimen,
+        eventName: PillEvent.addPillRegiment,
         date: currentDateStorage,
         startDateTime: date,
         pillToTake: pillWithInfo));
@@ -143,7 +143,7 @@ void main() async {
 
     BuildContext context = tester.element(find.byType(Scaffold));
     context.read<PillBloc>().add(PillsEvent(
-        eventName: PillEvent.addPillRegimen,
+        eventName: PillEvent.addPillRegiment,
         date: currentDateStorage,
         startDateTime: date,
         pillToTake: pillWithInfo));
@@ -167,7 +167,7 @@ void main() async {
 
     BuildContext context = tester.element(find.byType(Scaffold));
     context.read<PillBloc>().add(PillsEvent(
-        eventName: PillEvent.addPillRegimen,
+        eventName: PillEvent.addPillRegiment,
         date: currentDateStorage,
         startDateTime: date,
         pillToTake: pillToTake));

--- a/test/pill_widget_test.dart
+++ b/test/pill_widget_test.dart
@@ -74,7 +74,7 @@ void main() async {
                         child: ListView.builder(
                             itemCount: state.pillsToTake!.length,
                             itemBuilder: (_, index) => Dismissible(
-                                key: ObjectKey(
+                                key: ValueKey(
                                     state.pillsToTake![index].pillName),
                                 child: PillWidget(
                                   pillToTake: state.pillsToTake![index],

--- a/test/shared_preferences_test.dart
+++ b/test/shared_preferences_test.dart
@@ -51,6 +51,62 @@ void main() {
     expect(found.length, 1);
   });
 
+  group("SharedPreferences Service addPillToDate", () {
+    test("persists correctly", () async {
+      const PillToTake pill = PillToTake(
+          pillName: "Single Date Pill", pillRegiment: 1, amountOfDaysToTake: 1);
+      
+      final returnedPills = await sharedPreferencesService.addPillToDate(pill, fixedDate);
+      
+      expect(returnedPills.length, 1);
+      expect(returnedPills[0].pillName, "Single Date Pill");
+      
+      final storedPills = sharedPreferencesService.getPillsToTakeForDate(fixedDate);
+      expect(storedPills.length, 1);
+      expect(storedPills[0].pillName, "Single Date Pill");
+    });
+
+    test("trims pill name before persisting", () async {
+      const PillToTake pill = PillToTake(
+          pillName: "  Trim Me  ", pillRegiment: 1, amountOfDaysToTake: 1);
+      
+      await sharedPreferencesService.addPillToDate(pill, fixedDate);
+      
+      final storedPills = sharedPreferencesService.getPillsToTakeForDate(fixedDate);
+      expect(storedPills[0].pillName, "Trim Me");
+    });
+
+    test("prevents duplicates (case-insensitive and trimmed)", () async {
+      const PillToTake pill1 = PillToTake(
+          pillName: "Pill A", pillRegiment: 1, amountOfDaysToTake: 1);
+      const PillToTake pill2 = PillToTake(
+          pillName: "  pill a  ", pillRegiment: 2, amountOfDaysToTake: 1);
+      
+      await sharedPreferencesService.addPillToDate(pill1, fixedDate);
+      final result = await sharedPreferencesService.addPillToDate(pill2, fixedDate);
+      
+      expect(result.length, 1);
+      expect(result[0].pillName, "Pill A");
+      expect(result[0].pillRegiment, 1); // Should not have updated to 2
+      
+      final storedPills = sharedPreferencesService.getPillsToTakeForDate(fixedDate);
+      expect(storedPills.length, 1);
+    });
+
+    test("allows different pills", () async {
+      const PillToTake pill1 = PillToTake(
+          pillName: "Pill A", pillRegiment: 1, amountOfDaysToTake: 1);
+      const PillToTake pill2 = PillToTake(
+          pillName: "Pill B", pillRegiment: 1, amountOfDaysToTake: 1);
+      
+      await sharedPreferencesService.addPillToDate(pill1, fixedDate);
+      await sharedPreferencesService.addPillToDate(pill2, fixedDate);
+      
+      final storedPills = sharedPreferencesService.getPillsToTakeForDate(fixedDate);
+      expect(storedPills.length, 2);
+    });
+  });
+
   test("SharedPreferences Service remove pill from date", () async {
     const PillToTake pill = PillToTake(
         pillName: "Test Pill", pillRegiment: 2, amountOfDaysToTake: 1);

--- a/test/shared_preferences_test.dart
+++ b/test/shared_preferences_test.dart
@@ -107,6 +107,43 @@ void main() {
     });
   });
 
+  group("SharedPreferences Service addPillToDates", () {
+    test("prevents duplicates across multiple days (case-insensitive and trimmed)", () async {
+      const PillToTake pill1 = PillToTake(
+          pillName: "Pill A", pillRegiment: 1, amountOfDaysToTake: 2);
+      
+      // Add pill1 for 2 days
+      await sharedPreferencesService.addPillToDates(fixedNow, pill1);
+      
+      // Attempt to add a duplicate with different casing/spacing
+      const PillToTake pill2 = PillToTake(
+          pillName: "  pill a  ", pillRegiment: 2, amountOfDaysToTake: 2);
+      await sharedPreferencesService.addPillToDates(fixedNow, pill2);
+
+      // Verify for both days
+      for (int i = 0; i < 2; i++) {
+        final date = dateService.formatDateForStorage(fixedNow.add(Duration(days: i)));
+        final storedPills = sharedPreferencesService.getPillsToTakeForDate(date);
+        expect(storedPills.length, 1, reason: "Date offset $i should only have 1 pill");
+        expect(storedPills[0].pillName, "Pill A");
+        expect(storedPills[0].pillRegiment, 1);
+      }
+    });
+
+    test("trims pill name before persisting for all dates", () async {
+      const PillToTake pill = PillToTake(
+          pillName: "  Trim Me  ", pillRegiment: 1, amountOfDaysToTake: 2);
+      
+      await sharedPreferencesService.addPillToDates(fixedNow, pill);
+      
+      for (int i = 0; i < 2; i++) {
+        final date = dateService.formatDateForStorage(fixedNow.add(Duration(days: i)));
+        final storedPills = sharedPreferencesService.getPillsToTakeForDate(date);
+        expect(storedPills[0].pillName, "Trim Me");
+      }
+    });
+  });
+
   test("SharedPreferences Service remove pill from date", () async {
     const PillToTake pill = PillToTake(
         pillName: "Test Pill", pillRegiment: 2, amountOfDaysToTake: 1);

--- a/test/shared_preferences_test.dart
+++ b/test/shared_preferences_test.dart
@@ -38,7 +38,7 @@ void main() {
 
   test("SharedPreferences Service add pill to date", () async {
     const PillToTake pill = PillToTake(
-        pillName: "Test Pill", pillRegiment: 2, amountOfDaysToTake: 1);
+        id: "test_id", pillName: "Test Pill", pillRegiment: 2, amountOfDaysToTake: 1);
     await sharedPreferencesService.addPillToDates(fixedNow, pill);
     List<PillToTake> pills =
         sharedPreferencesService.getPillsToTakeForDate(fixedDate);
@@ -46,7 +46,7 @@ void main() {
     expect(pills.length, 1);
 
     List<PillToTake> found =
-        pills.where((element) => element.pillName == pill.pillName).toList();
+        pills.where((element) => element.id == pill.id).toList();
 
     expect(found.length, 1);
   });
@@ -54,7 +54,7 @@ void main() {
   group("SharedPreferences Service addPillToDate", () {
     test("persists correctly", () async {
       const PillToTake pill = PillToTake(
-          pillName: "Single Date Pill", pillRegiment: 1, amountOfDaysToTake: 1);
+          id: "id1", pillName: "Single Date Pill", pillRegiment: 1, amountOfDaysToTake: 1);
       
       final returnedPills = await sharedPreferencesService.addPillToDate(pill, fixedDate);
       
@@ -68,7 +68,7 @@ void main() {
 
     test("trims pill name before persisting", () async {
       const PillToTake pill = PillToTake(
-          pillName: "  Trim Me  ", pillRegiment: 1, amountOfDaysToTake: 1);
+          id: "id1", pillName: "  Trim Me  ", pillRegiment: 1, amountOfDaysToTake: 1);
       
       await sharedPreferencesService.addPillToDate(pill, fixedDate);
       
@@ -78,9 +78,9 @@ void main() {
 
     test("prevents duplicates (case-insensitive and trimmed)", () async {
       const PillToTake pill1 = PillToTake(
-          pillName: "Pill A", pillRegiment: 1, amountOfDaysToTake: 1);
+          id: "id1", pillName: "Pill A", pillRegiment: 1, amountOfDaysToTake: 1);
       const PillToTake pill2 = PillToTake(
-          pillName: "  pill a  ", pillRegiment: 2, amountOfDaysToTake: 1);
+          id: "id2", pillName: "  pill a  ", pillRegiment: 2, amountOfDaysToTake: 1);
       
       await sharedPreferencesService.addPillToDate(pill1, fixedDate);
       final result = await sharedPreferencesService.addPillToDate(pill2, fixedDate);
@@ -95,9 +95,9 @@ void main() {
 
     test("allows different pills", () async {
       const PillToTake pill1 = PillToTake(
-          pillName: "Pill A", pillRegiment: 1, amountOfDaysToTake: 1);
+          id: "id1", pillName: "Pill A", pillRegiment: 1, amountOfDaysToTake: 1);
       const PillToTake pill2 = PillToTake(
-          pillName: "Pill B", pillRegiment: 1, amountOfDaysToTake: 1);
+          id: "id2", pillName: "Pill B", pillRegiment: 1, amountOfDaysToTake: 1);
       
       await sharedPreferencesService.addPillToDate(pill1, fixedDate);
       await sharedPreferencesService.addPillToDate(pill2, fixedDate);
@@ -110,14 +110,14 @@ void main() {
   group("SharedPreferences Service addPillToDates", () {
     test("prevents duplicates across multiple days (case-insensitive and trimmed)", () async {
       const PillToTake pill1 = PillToTake(
-          pillName: "Pill A", pillRegiment: 1, amountOfDaysToTake: 2);
+          id: "id1", pillName: "Pill A", pillRegiment: 1, amountOfDaysToTake: 2);
       
       // Add pill1 for 2 days
       await sharedPreferencesService.addPillToDates(fixedNow, pill1);
       
       // Attempt to add a duplicate with different casing/spacing
       const PillToTake pill2 = PillToTake(
-          pillName: "  pill a  ", pillRegiment: 2, amountOfDaysToTake: 2);
+          id: "id2", pillName: "  pill a  ", pillRegiment: 2, amountOfDaysToTake: 2);
       await sharedPreferencesService.addPillToDates(fixedNow, pill2);
 
       // Verify for both days
@@ -132,7 +132,7 @@ void main() {
 
     test("trims pill name before persisting for all dates", () async {
       const PillToTake pill = PillToTake(
-          pillName: "  Trim Me  ", pillRegiment: 1, amountOfDaysToTake: 2);
+          id: "id1", pillName: "  Trim Me  ", pillRegiment: 1, amountOfDaysToTake: 2);
       
       await sharedPreferencesService.addPillToDates(fixedNow, pill);
       
@@ -146,7 +146,7 @@ void main() {
 
   test("SharedPreferences Service remove pill from date", () async {
     const PillToTake pill = PillToTake(
-        pillName: "Test Pill", pillRegiment: 2, amountOfDaysToTake: 1);
+        id: "id1", pillName: "Test Pill", pillRegiment: 2, amountOfDaysToTake: 1);
     await sharedPreferencesService.addPillToDates(fixedNow, pill);
     List<PillToTake> pills =
         sharedPreferencesService.getPillsToTakeForDate(fixedDate);
@@ -164,12 +164,12 @@ void main() {
       "SharedPreferences Service remove pill from date (case-insensitive and trimmed)",
       () async {
     const PillToTake pill = PillToTake(
-        pillName: "Test Pill", pillRegiment: 2, amountOfDaysToTake: 1);
+        id: "id1", pillName: "Test Pill", pillRegiment: 2, amountOfDaysToTake: 1);
     await sharedPreferencesService.addPillToDates(fixedNow, pill);
 
     // Attempt removal with different casing and whitespace
     const PillToTake pillToRemove = PillToTake(
-        pillName: "  test pill  ", pillRegiment: 2, amountOfDaysToTake: 1);
+        id: "id1", pillName: "  test pill  ", pillRegiment: 2, amountOfDaysToTake: 1);
 
     await sharedPreferencesService.removePillFromDate(pillToRemove, fixedDate);
 
@@ -180,7 +180,7 @@ void main() {
 
   test("SharedPreferences Service update pill from date", () async {
     const PillToTake pill = PillToTake(
-        pillName: "Test Pill", pillRegiment: 2, amountOfDaysToTake: 1);
+        id: "id1", pillName: "Test Pill", pillRegiment: 2, amountOfDaysToTake: 1);
     await sharedPreferencesService.addPillToDates(fixedNow, pill);
     List<PillToTake> pills =
         sharedPreferencesService.getPillsToTakeForDate(fixedDate);
@@ -202,12 +202,12 @@ void main() {
       "SharedPreferences Service update pill from date (case-insensitive and trimmed)",
       () async {
     const PillToTake pill = PillToTake(
-        pillName: "Test Pill", pillRegiment: 2, amountOfDaysToTake: 1);
+        id: "id1", pillName: "Test Pill", pillRegiment: 2, amountOfDaysToTake: 1);
     await sharedPreferencesService.addPillToDates(fixedNow, pill);
 
     // Update with different casing and whitespace
     const PillToTake updatedPillInstance = PillToTake(
-        pillName: "  test pill  ", pillRegiment: 10, amountOfDaysToTake: 1);
+        id: "id1", pillName: "  test pill  ", pillRegiment: 10, amountOfDaysToTake: 1);
 
     await sharedPreferencesService.updatePillForDate(updatedPillInstance, fixedDate);
 
@@ -221,7 +221,7 @@ void main() {
       "SharedPreferences Service update pill from date - pill not found guard",
       () async {
     const PillToTake pill = PillToTake(
-        pillName: "Non Existent Pill", pillRegiment: 2, amountOfDaysToTake: 1);
+        id: "id1", pillName: "Non Existent Pill", pillRegiment: 2, amountOfDaysToTake: 1);
 
     // This should not throw RangeError
     await sharedPreferencesService.updatePillForDate(pill, fixedDate);
@@ -239,6 +239,7 @@ void main() {
   test("SharedPreferences Service pillImage persistence", () async {
     const String customImage = "assets/images/custom_pill.png";
     const PillToTake pill = PillToTake(
+        id: "id1",
         pillName: "Custom Image Pill",
         pillRegiment: 2,
         amountOfDaysToTake: 1,
@@ -258,7 +259,7 @@ void main() {
 
   test("SharedPreferences Service Clearing All Pills", () async {
     const PillToTake pill = PillToTake(
-        pillName: "Test Pill", pillRegiment: 2, amountOfDaysToTake: 1);
+        id: "id1", pillName: "Test Pill", pillRegiment: 2, amountOfDaysToTake: 1);
     await sharedPreferencesService.addPillToDates(fixedNow, pill);
     List<PillToTake> pills =
         sharedPreferencesService.getPillsToTakeForDate(fixedDate);
@@ -280,7 +281,7 @@ void main() {
   group("SharedPreferences Service migration", () {
     test("Full migration (Yearly + Prefixed + Delimiter)", () async {
       const pill = PillToTake(
-          pillName: "Test Pill", pillRegiment: 1, amountOfDaysToTake: 1);
+          id: "id1", pillName: "Test Pill", pillRegiment: 1, amountOfDaysToTake: 1);
       final pillTaken = PillTaken(
           pillName: "Test Pill", lastTaken: DateTime(2023, 3, 29, 10));
 
@@ -331,7 +332,7 @@ void main() {
 
     test("Migration from Prefixed to Delimiter only", () async {
       const pill = PillToTake(
-          pillName: "Test Pill", pillRegiment: 1, amountOfDaysToTake: 1);
+          id: "id1", pillName: "Test Pill", pillRegiment: 1, amountOfDaysToTake: 1);
       final String pillsValue = PillToTake.encode([pill]);
 
       SharedPreferences.setMockInitialValues({
@@ -352,9 +353,9 @@ void main() {
     test("Migration with conflict resolution (merge data)", () async {
       const int migrationYear = 2026;
       const pill1 = PillToTake(
-          pillName: "Pill A", pillRegiment: 1, amountOfDaysToTake: 7);
+          id: "id1", pillName: "Pill A", pillRegiment: 1, amountOfDaysToTake: 7);
       const pill2 = PillToTake(
-          pillName: "Pill B", pillRegiment: 2, amountOfDaysToTake: 7);
+          id: "id2", pillName: "Pill B", pillRegiment: 2, amountOfDaysToTake: 7);
 
       final pillTaken1 = PillTaken(
           pillName: "Pill A",


### PR DESCRIPTION
Resolves #84 

This pull request introduces a significant improvement to the pill management workflow, focusing on enabling undo functionality when dismissing (removing) a pill from the daily list. The changes add a new event for re-adding a pill to a specific date, refactor the event handling in the bloc, update the UI to support immediate feedback and undo, and extend test coverage for these behaviors.

**Key changes include:**

### Pill Event and Bloc Enhancements

* Added new events (`addPillRegiment`, `addPillToDate`) to the `PillEvent` enum and updated the `PillBloc` to handle these events with corresponding methods. This allows for distinguishing between adding a regiment of pills and re-adding a single pill to a specific date (for undo purposes). [[1]](diffhunk://#diff-0aa009393ba22cec8aa010fee61aa9864adb00c93c91fbb4ca0f3afe072e08c3L10-R11) [[2]](diffhunk://#diff-0aa009393ba22cec8aa010fee61aa9864adb00c93c91fbb4ca0f3afe072e08c3L41-R46) [[3]](diffhunk://#diff-0aa009393ba22cec8aa010fee61aa9864adb00c93c91fbb4ca0f3afe072e08c3L61-R65) [[4]](diffhunk://#diff-0aa009393ba22cec8aa010fee61aa9864adb00c93c91fbb4ca0f3afe072e08c3R84-R95)
* Updated the UI and test code to use `addPillRegiment` instead of the old `addPill` event, ensuring consistency with the new event structure. [[1]](diffhunk://#diff-3380c5459deab6704f806f4e391b9e4b73fd53fcd941fb0cb638c52d1b8583d5L302-R302) [[2]](diffhunk://#diff-d3e98c1bbb2296128df088967995767bf4caba82cb1df2860ffaa4927e657116L109-R109) [[3]](diffhunk://#diff-d3e98c1bbb2296128df088967995767bf4caba82cb1df2860ffaa4927e657116L146-R146) [[4]](diffhunk://#diff-d3e98c1bbb2296128df088967995767bf4caba82cb1df2860ffaa4927e657116L170-R170)

### Shared Preferences Service Updates

* Added `addPillToDate` method to `SharedPreferencesService` to support re-adding a pill to a specific date, and ensured pills are not duplicated by normalizing names. The existing `addPillToDates` method was also improved to avoid duplicates.

### Day Widget UI/UX Improvements

* Refactored `DayWidget` from a `StatelessWidget` to a `StatefulWidget` to maintain a local copy of the pills list, enabling immediate UI updates upon dismissing a pill.
* Implemented swipe-to-dismiss with an undo `SnackBar`. When a pill is dismissed, it is immediately removed from the local list, and the user is shown a `SnackBar` with an undo action. If undo is tapped, the pill is re-added for that date via the new bloc event. [[1]](diffhunk://#diff-a9573fd486568e90b511783359831d3de5512b4b4e8314e33648fb5da00fa902R1) [[2]](diffhunk://#diff-a9573fd486568e90b511783359831d3de5512b4b4e8314e33648fb5da00fa902L16-R17) [[3]](diffhunk://#diff-a9573fd486568e90b511783359831d3de5512b4b4e8314e33648fb5da00fa902L27-L52) [[4]](diffhunk://#diff-a9573fd486568e90b511783359831d3de5512b4b4e8314e33648fb5da00fa902L61-R157)
* Updated the bloc consumer logic in `DayWidget` to carefully synchronize the local pill list with bloc state, preventing race conditions or unwanted reintroductions of pills. [[1]](diffhunk://#diff-a9573fd486568e90b511783359831d3de5512b4b4e8314e33648fb5da00fa902L91-R176) [[2]](diffhunk://#diff-a9573fd486568e90b511783359831d3de5512b4b4e8314e33648fb5da00fa902L108-R239)

### Testing

* Added comprehensive widget tests for the new dismiss-with-undo workflow, including tests for successful undo and for verifying that only end-to-start swipes trigger dismissals. [[1]](diffhunk://#diff-144888754bbcae9c78b542db2a9147fb103661c558065eef22170e3a6af7fc68R14-R36) [[2]](diffhunk://#diff-144888754bbcae9c78b542db2a9147fb103661c558065eef22170e3a6af7fc68L112-R125) [[3]](diffhunk://#diff-144888754bbcae9c78b542db2a9147fb103661c558065eef22170e3a6af7fc68R156-R215)
* Minor test and key improvements for consistency and robustness.

---

**References:**  
Pill Event/Bloc: [[1]](diffhunk://#diff-0aa009393ba22cec8aa010fee61aa9864adb00c93c91fbb4ca0f3afe072e08c3L10-R11) [[2]](diffhunk://#diff-0aa009393ba22cec8aa010fee61aa9864adb00c93c91fbb4ca0f3afe072e08c3L41-R46) [[3]](diffhunk://#diff-0aa009393ba22cec8aa010fee61aa9864adb00c93c91fbb4ca0f3afe072e08c3L61-R65) [[4]](diffhunk://#diff-0aa009393ba22cec8aa010fee61aa9864adb00c93c91fbb4ca0f3afe072e08c3R84-R95) [[5]](diffhunk://#diff-3380c5459deab6704f806f4e391b9e4b73fd53fcd941fb0cb638c52d1b8583d5L302-R302) [[6]](diffhunk://#diff-d3e98c1bbb2296128df088967995767bf4caba82cb1df2860ffaa4927e657116L109-R109) [[7]](diffhunk://#diff-d3e98c1bbb2296128df088967995767bf4caba82cb1df2860ffaa4927e657116L146-R146) [[8]](diffhunk://#diff-d3e98c1bbb2296128df088967995767bf4caba82cb1df2860ffaa4927e657116L170-R170)  
Service:  
UI/UX: [[1]](diffhunk://#diff-a9573fd486568e90b511783359831d3de5512b4b4e8314e33648fb5da00fa902R1) [[2]](diffhunk://#diff-a9573fd486568e90b511783359831d3de5512b4b4e8314e33648fb5da00fa902L16-R17) [[3]](diffhunk://#diff-a9573fd486568e90b511783359831d3de5512b4b4e8314e33648fb5da00fa902L27-L52) [[4]](diffhunk://#diff-a9573fd486568e90b511783359831d3de5512b4b4e8314e33648fb5da00fa902L61-R157) [[5]](diffhunk://#diff-a9573fd486568e90b511783359831d3de5512b4b4e8314e33648fb5da00fa902L91-R176) [[6]](diffhunk://#diff-a9573fd486568e90b511783359831d3de5512b4b4e8314e33648fb5da00fa902L108-R239)  
Testing: [[1]](diffhunk://#diff-144888754bbcae9c78b542db2a9147fb103661c558065eef22170e3a6af7fc68R14-R36) [[2]](diffhunk://#diff-144888754bbcae9c78b542db2a9147fb103661c558065eef22170e3a6af7fc68L112-R125) [[3]](diffhunk://#diff-144888754bbcae9c78b542db2a9147fb103661c558065eef22170e3a6af7fc68R156-R215) [[4]](diffhunk://#diff-d3e98c1bbb2296128df088967995767bf4caba82cb1df2860ffaa4927e657116L77-R77)