### PR TITLE
When pill is dismissed, snackbar does not disappear

### DIFF
--- a/lib/widget/day_widget.dart
+++ b/lib/widget/day_widget.dart
@@ -141,9 +141,8 @@ class _DayWidgetState extends State<DayWidget> {
                   onPressed: () {
                     // Clear tracking synchronously before dispatching so the
                     // listener doesn't block the incoming state update.
-                    setState(() {
-                      _locallyRemovedNames.remove(pill.pillName.trim().toLowerCase());
-                    });
+                    _locallyRemovedNames.remove(
+                        pill.pillName.trim().toLowerCase());
                     context.read<PillBloc>().add(PillsEvent(
                         eventName: PillEvent.addPillToDate,
                         date: widgetDateStr,

--- a/lib/widget/day_widget.dart
+++ b/lib/widget/day_widget.dart
@@ -130,21 +130,18 @@ class _DayWidgetState extends State<DayWidget> {
                 date: widgetDateStr,
                 pillToTake: pill));
 
-            ScaffoldMessenger.of(context).hideCurrentSnackBar();
             ScaffoldMessenger.of(context).showSnackBar(
               SnackBar(
                 content: Text('${pill.pillName} removed'),
-                behavior: SnackBarBehavior.floating,
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(10),
-                ),
+                persist: false,
                 action: SnackBarAction(
                   label: 'Undo',
                   onPressed: () {
                     // Clear tracking synchronously before dispatching so the
                     // listener doesn't block the incoming state update.
-                    _locallyRemovedNames
-                        .remove(pill.pillName.trim().toLowerCase());
+                    setState(() {
+                      _locallyRemovedNames.remove(pill.pillName.trim().toLowerCase());
+                    });
                     context.read<PillBloc>().add(PillsEvent(
                         eventName: PillEvent.addPillToDate,
                         date: widgetDateStr,

--- a/lib/widget/day_widget.dart
+++ b/lib/widget/day_widget.dart
@@ -130,7 +130,9 @@ class _DayWidgetState extends State<DayWidget> {
                 date: widgetDateStr,
                 pillToTake: pill));
 
-            ScaffoldMessenger.of(context).showSnackBar(
+            final scaffoldMessenger = ScaffoldMessenger.of(context);
+            scaffoldMessenger.clearSnackBars();
+            scaffoldMessenger.showSnackBar(
               SnackBar(
                 content: Text('${pill.pillName} removed'),
                 persist: false,

--- a/test/day_widget_test.dart
+++ b/test/day_widget_test.dart
@@ -190,6 +190,32 @@ void main() {
         expect(find.text('Dismiss Pill'), findsOneWidget);
       });
 
+  testWidgets('DayWidget Snackbar disappears after duration',
+          (WidgetTester tester) async {
+        const pill = PillToTake(
+            pillName: 'Timed Pill', pillRegiment: 1, amountOfDaysToTake: 1);
+
+        await seedBlocState(tester, () async {
+          await sharedPreferencesService.addPillToDates(testDate, pill);
+        });
+
+        await tester.pumpWidget(createWidgetUnderTest(mode: DayWidgetMode.toTake));
+        await tester.pumpAndSettle();
+
+        // Swipe end-to-start (right to left) to dismiss.
+        await tester.drag(find.byType(Dismissible), const Offset(-500, 0));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Timed Pill removed'), findsOneWidget);
+
+        // Default SnackBar duration is 4 seconds.
+        // We pump for longer than that to ensure it's gone.
+        await tester.pump(const Duration(seconds: 5));
+        await tester.pumpAndSettle();
+
+        expect(find.text('Timed Pill removed'), findsNothing);
+      });
+
   testWidgets('DayWidget dismisses one of multiple pills and undos correctly',
           (WidgetTester tester) async {
         // Increase surface size to ensure all 3 pills are rendered by ListView.builder


### PR DESCRIPTION
Fixes #100 

This pull request improves the user experience for pill removal notifications in the `DayWidget` by updating how SnackBars are displayed and adding a test to ensure they disappear after the expected duration. The main changes involve updating the SnackBar presentation logic and expanding test coverage.

**SnackBar behavior improvements:**

* Replaced `hideCurrentSnackBar()` with `clearSnackBars()` for more robust SnackBar management and set the `persist` property to `false` to ensure SnackBars automatically disappear after their duration. Also, removed custom styling from the SnackBar for simplicity. (`lib/widget/day_widget.dart`)

**Test coverage:**

* Added a widget test to verify that the SnackBar in `DayWidget` disappears after its default duration, ensuring correct behavior for temporary notifications. (`test/day_widget_test.dart`)