### PR TITLE
_DayWidgetState seeds _localPills from initState but ignores pillsTaken mode — causes null list on first build

### DIFF
--- a/lib/widget/day_widget.dart
+++ b/lib/widget/day_widget.dart
@@ -30,7 +30,7 @@ class DayWidget extends StatefulWidget {
 class _DayWidgetState extends State<DayWidget> {
   // Local copy of the pill list, kept in sync with bloc via BlocConsumer.
   // Mutated immediately on dismiss so Dismissible is satisfied synchronously.
-  List<PillToTake>? _localPills;
+  List<PillToTake> _localPills = [];
 
   // Track names of pills dismissed locally but not yet confirmed removed by
   // the bloc, so we don't re-introduce them prematurely from a stale emission.
@@ -45,9 +45,11 @@ class _DayWidgetState extends State<DayWidget> {
     super.initState();
     // Seed from the current bloc state so the list is populated on the very
     // first build, before the BlocConsumer listener has a chance to fire.
-    final currentState = context.read<PillBloc>().state;
-    if (currentState.pillsToTake != null) {
-      _localPills = List.from(currentState.pillsToTake!);
+    if (widget.mode == DayWidgetMode.toTake) {
+      final pills = context.read<PillBloc>().state.pillsToTake;
+      if (pills != null) {
+        _localPills = List.from(pills);
+      }
     }
   }
 
@@ -82,8 +84,7 @@ class _DayWidgetState extends State<DayWidget> {
   }
 
   Widget _pillsToTakeList(BuildContext context) {
-    final pills = _localPills;
-    if (pills == null || pills.isEmpty) {
+    if (_localPills.isEmpty) {
       return Padding(
           padding: const EdgeInsets.only(top: 20),
           child: Text(_header,
@@ -92,9 +93,9 @@ class _DayWidgetState extends State<DayWidget> {
     }
 
     return ListView.builder(
-      itemCount: pills.length,
+      itemCount: _localPills.length,
       itemBuilder: (_, index) {
-        final pill = pills[index];
+        final pill = _localPills[index];
         return Dismissible(
           key: ObjectKey(pill.pillName),
           direction: DismissDirection.endToStart,
@@ -121,7 +122,7 @@ class _DayWidgetState extends State<DayWidget> {
 
             // Remove from local list immediately — Flutter requires this.
             setState(() {
-              _localPills!.remove(pill);
+              _localPills.remove(pill);
               _locallyRemovedNames.add(pill.pillName.trim().toLowerCase());
             });
 


### PR DESCRIPTION
Fixes #104 

This pull request refactors how the `_localPills` list is managed in the `DayWidget` to simplify its initialization and usage. The main changes are to ensure `_localPills` is always a non-null list, which reduces the need for null checks and simplifies the widget's logic.

**Initialization and null-safety improvements:**

* Changed `_localPills` from a nullable list to a non-nullable, empty list by default, eliminating the need for null checks throughout the widget (`lib/widget/day_widget.dart`).
* Updated the `initState` method to only populate `_localPills` when the widget is in `toTake` mode, and only if there are pills to take, ensuring correct initialization based on widget mode (`lib/widget/day_widget.dart`).

**Code simplification and consistency:**

* Simplified the `_pillsToTakeList` method to check only for emptiness (not null), and updated all references to `_localPills` to remove unnecessary null checks (`lib/widget/day_widget.dart`). [[1]](diffhunk://#diff-a9573fd486568e90b511783359831d3de5512b4b4e8314e33648fb5da00fa902L85-R87) [[2]](diffhunk://#diff-a9573fd486568e90b511783359831d3de5512b4b4e8314e33648fb5da00fa902L95-R98) [[3]](diffhunk://#diff-a9573fd486568e90b511783359831d3de5512b4b4e8314e33648fb5da00fa902L124-R125)

These changes make the widget's state management more robust and the code easier to read and maintain.