### PR TITLE
_updateNow in MainPage is called on settings tab tap but serves no clear purpose

### DIFF
--- a/lib/page/main_page.dart
+++ b/lib/page/main_page.dart
@@ -102,7 +102,11 @@ class _MainPageState extends State<MainPage> with WidgetsBindingObserver {
             appBar: _MainPageAppBar(
               key: const ValueKey('MainPageAppBar'),
               onPillsTabTapped: _loadPillsForToday,
-              onSettingsTabTapped: () => _updateNow(),
+              onSettingsTabTapped: () {
+                context
+                    .read<ClearPillsBloc>()
+                    .add(ClearPillsEvent.updatePillsStatus);
+              },
             ),
             body: _MainPageTabBarView(
               key: const ValueKey('MainPageTabBarView'),
@@ -142,9 +146,6 @@ class _MainPageAppBar extends StatelessWidget implements PreferredSizeWidget {
               break;
             case settingsTabIndex:
               onSettingsTabTapped();
-              context
-                  .read<ClearPillsBloc>()
-                  .add(ClearPillsEvent.updatePillsStatus);
               break;
           }
         },


### PR DESCRIPTION
Resolves #106 

This pull request updates the logic for handling the Settings tab in the `MainPage` of the app. The main change is to centralize the dispatching of the `updatePillsStatus` event so that it only occurs in one place, improving code clarity and maintainability.

**Refactoring event dispatch for Settings tab:**

* Moved the dispatch of `ClearPillsEvent.updatePillsStatus` from the `_MainPageAppBar` widget to the parent `_MainPageState`, ensuring the event is triggered only when the Settings tab is tapped and avoiding duplicate calls. [[1]](diffhunk://#diff-dc4226243b64aaad1b133ab036b397d41fe39c30be333ae0bb31fea217b382b8L105-R109) [[2]](diffhunk://#diff-dc4226243b64aaad1b133ab036b397d41fe39c30be333ae0bb31fea217b382b8L145-L147)